### PR TITLE
feat: add YouTube and Spotify music support

### DIFF
--- a/docs/superpowers/plans/2026-04-05-youtube-spotify-music.md
+++ b/docs/superpowers/plans/2026-04-05-youtube-spotify-music.md
@@ -1,0 +1,173 @@
+# YouTube & Spotify Music Support Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `youtube-ext` and `play-dl` bridge libraries so YouTube and Spotify links work, and show a rich embed when a playlist is queued.
+
+**Architecture:** `discord-player`'s `DefaultExtractors` already registers `YoutubeExtractor` and `SpotifyExtractor` — they just need their bridge libraries installed. `play.ts` is updated to check `searchResult.hasPlaylist()` on the result of `player.play()` and reply with an embed instead of plain text for playlists.
+
+**Tech Stack:** discord-player v7, @discord-player/extractor, youtube-ext, play-dl, discord.js EmbedBuilder
+
+---
+
+## File Map
+
+| File | Change |
+|---|---|
+| `package.json` | Add `youtube-ext` and `play-dl` as dependencies |
+| `pnpm-lock.yaml` | Auto-updated by pnpm |
+| `src/commands/music/play.ts` | Destructure `searchResult` from `player.play()`, add playlist embed branch |
+
+---
+
+### Task 1: Install bridge libraries
+
+**Files:**
+- Modify: `package.json`
+- Modify: `pnpm-lock.yaml`
+
+- [ ] **Step 1: Install youtube-ext and play-dl**
+
+```bash
+pnpm add youtube-ext play-dl
+```
+
+Expected output: two new entries appear in `package.json` `dependencies` and `pnpm-lock.yaml` is updated.
+
+- [ ] **Step 2: Verify they resolve**
+
+```bash
+node -e "require('youtube-ext'); require('play-dl'); console.log('ok')"
+```
+
+Expected: `ok`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add package.json pnpm-lock.yaml
+git commit -m "feat: add youtube-ext and play-dl bridge libraries"
+```
+
+---
+
+### Task 2: Add playlist embed to /play command
+
+**Files:**
+- Modify: `src/commands/music/play.ts`
+
+- [ ] **Step 1: Update the import line to add EmbedBuilder**
+
+In `src/commands/music/play.ts`, change:
+
+```ts
+import { Command } from "@sapphire/framework";
+import { GuildMember } from "discord.js";
+import { useMainPlayer } from "discord-player";
+```
+
+to:
+
+```ts
+import { Command } from "@sapphire/framework";
+import { EmbedBuilder, GuildMember } from "discord.js";
+import { useMainPlayer } from "discord-player";
+```
+
+- [ ] **Step 2: Replace the chatInputRun method body**
+
+Replace the entire `chatInputRun` method with the following. The only change is inside the `try` block: destructure `searchResult` from `player.play()`, and branch on `searchResult.hasPlaylist()`.
+
+```ts
+public override async chatInputRun(interaction: Command.ChatInputCommandInteraction) {
+	const member = interaction.member as GuildMember;
+	const voiceChannel = member.voice.channel;
+
+	if (!voiceChannel) {
+		return interaction.reply({ content: "You need to be in a voice channel to play music.", ephemeral: true });
+	}
+
+	const query = interaction.options.getString("query", true);
+	const player = useMainPlayer();
+
+	await interaction.deferReply();
+
+	try {
+		const { track, searchResult } = await player.play(voiceChannel, query, {
+			nodeOptions: {
+				metadata: {
+					channel: interaction.channel,
+					requestedBy: interaction.user,
+				},
+				selfDeaf: true,
+				volume: 80,
+				leaveOnEmpty: true,
+				leaveOnEmptyCooldown: 30_000,
+				leaveOnEnd: true,
+				leaveOnEndCooldown: 30_000,
+			},
+			requestedBy: interaction.user,
+		});
+
+		if (searchResult.hasPlaylist() && searchResult.playlist) {
+			const playlist = searchResult.playlist;
+			const tracks = searchResult.tracks;
+			const isSpotify = query.includes("open.spotify.com");
+			const color = isSpotify ? 0x1db954 : 0xff0000;
+
+			const trackList = tracks
+				.slice(0, 5)
+				.map((t, i) => `${i + 1}. **${t.title}** — ${t.author}`)
+				.join("\n");
+
+			const embed = new EmbedBuilder()
+				.setColor(color)
+				.setTitle(playlist.title)
+				.setURL(playlist.url || null)
+				.setDescription(trackList)
+				.setFooter({
+					text: `Queued by ${interaction.user.username} · ${tracks.length} tracks`,
+				});
+
+			return interaction.editReply({ embeds: [embed] });
+		}
+
+		return interaction.editReply({ content: `Queued: **${track.title}** by **${track.author}**` });
+	} catch (error) {
+		const message = error instanceof Error ? error.message : "Unknown error";
+		return interaction.editReply({ content: `Failed to play: ${message}` });
+	}
+}
+```
+
+- [ ] **Step 3: Verify TypeScript compiles cleanly**
+
+```bash
+pnpm build
+```
+
+Expected: no errors, `dist/` updated.
+
+- [ ] **Step 4: Manual smoke test**
+
+Start the bot:
+
+```bash
+pnpm dev
+```
+
+Test these three cases in Discord:
+
+| Input | Expected response |
+|---|---|
+| `/play never gonna give you up` | Plain text: `Queued: Never Gonna Give You Up by Rick Astley` |
+| `/play https://www.youtube.com/watch?v=dQw4w9WgXcQ` | Plain text: `Queued: Never Gonna Give You Up by Rick Astley` |
+| `/play https://www.youtube.com/playlist?list=<any public playlist>` | Embed with playlist name, first 5 tracks, footer with track count |
+| `/play https://open.spotify.com/playlist/<id>` | Embed with green color, playlist name, first 5 tracks |
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/commands/music/play.ts
+git commit -m "feat: show playlist embed when queuing YouTube or Spotify playlist"
+```

--- a/docs/superpowers/specs/2026-04-05-youtube-spotify-music-design.md
+++ b/docs/superpowers/specs/2026-04-05-youtube-spotify-music-design.md
@@ -1,0 +1,82 @@
+# YouTube & Spotify Music Support
+
+**Date:** 2026-04-05
+**Status:** Approved
+
+## Problem
+
+The bot uses `discord-player` v7 with `DefaultExtractors`, which includes `YoutubeExtractor` and `SpotifyExtractor`. However, neither works because the required bridge libraries (`youtube-ext` for YouTube, `play-dl` for Spotify) are not installed. Additionally, playlist responses are indistinguishable from single-track responses.
+
+## Goals
+
+- YouTube links, YouTube playlist links, and YouTube search queries work
+- Spotify track and playlist links work
+- When a playlist is queued, show a rich embed with playlist name, track count, and first 5 tracks
+- Single track responses remain as-is (plain text)
+
+## Out of Scope
+
+- Spotify search queries (Spotify requires OAuth; `play-dl` resolves Spotify URLs by bridging to YouTube)
+- Per-channel source restrictions
+- Different embed styles per source
+
+## Design
+
+### Dependencies
+
+Install two packages as runtime dependencies:
+
+| Package | Purpose |
+|---|---|
+| `youtube-ext` | Bridge library for `YoutubeExtractor` in `@discord-player/extractor` |
+| `play-dl` | Bridge library for `SpotifyExtractor` in `@discord-player/extractor` |
+
+No changes to extractor registration — `DefaultExtractors` already registers both extractors in `src/index.ts`. The bridge libraries just need to be present in `node_modules`.
+
+### `src/commands/music/play.ts` changes
+
+`player.play()` returns `{ track, queue, searchResult }`. When a playlist URL is passed, `searchResult.playlist` is populated with the full playlist object and `searchResult.tracks` contains all queued tracks.
+
+**Detection logic:**
+
+```
+if searchResult.playlist exists
+  → reply with playlist embed
+else
+  → reply with existing plain-text message (no change)
+```
+
+**Playlist embed fields:**
+
+| Field | Value |
+|---|---|
+| Title | `searchResult.playlist.title` (linked to original URL) |
+| Color | `0xFF0000` (YouTube red) or `0x1DB954` (Spotify green) |
+| Description | First 5 tracks from `searchResult.tracks` listed as `1. Title — Author` |
+| Footer | `Queued by <username>` · `X tracks` |
+
+Source is detected from the query string — if it contains `open.spotify.com` it's Spotify, otherwise YouTube.
+
+### Data flow
+
+```
+/play <query or URL>
+  → player.play(voiceChannel, query, nodeOptions)
+  → discord-player checks each registered extractor's validate()
+  → YoutubeExtractor handles youtube.com / youtu.be / plain search queries
+  → SpotifyExtractor handles open.spotify.com URLs (bridges to YouTube via play-dl)
+  → returns { track, queue, searchResult }
+  → searchResult.playlist? → embed reply : plain-text reply
+```
+
+### Error handling
+
+No changes — existing try/catch in `play.ts` already catches and reports failures from `player.play()`. Library-level errors (e.g. rate limits, private videos) surface through this path.
+
+## Files Changed
+
+| File | Change |
+|---|---|
+| `package.json` | Add `youtube-ext` and `play-dl` dependencies |
+| `pnpm-lock.yaml` | Updated by pnpm |
+| `src/commands/music/play.ts` | Add playlist embed response branch |

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@sapphire/plugin-logger": "^4.1.0",
     "@sapphire/plugin-scheduled-tasks": "^10.0.4",
     "@sapphire/plugin-subcommands": "^7.0.1",
+    "@snazzah/davey": "^0.1.11",
     "bullmq": "^5.73.0",
     "discord-html-transcripts": "^3.2.0",
     "discord-player": "^7.2.0",
@@ -35,6 +36,8 @@
     "ioredis": "^5.10.1",
     "ms": "^2.1.3",
     "pg": "^8.20.0",
+    "play-dl": "^1.9.7",
+    "youtube-ext": "^1.1.25",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       '@sapphire/plugin-subcommands':
         specifier: ^7.0.1
         version: 7.0.1
+      '@snazzah/davey':
+        specifier: ^0.1.11
+        version: 0.1.11(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
       bullmq:
         specifier: ^5.73.0
         version: 5.73.0
@@ -53,6 +56,12 @@ importers:
       pg:
         specifier: ^8.20.0
         version: 8.20.0
+      play-dl:
+        specifier: ^1.9.7
+        version: 1.9.7
+      youtube-ext:
+        specifier: ^1.1.25
+        version: 1.1.25
       zod:
         specifier: ^4.3.6
         version: 4.3.6
@@ -194,6 +203,15 @@ packages:
 
   '@drizzle-team/brocli@0.10.2':
     resolution: {integrity: sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w==}
+
+  '@emnapi/core@1.9.2':
+    resolution: {integrity: sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==}
+
+  '@emnapi/runtime@1.9.2':
+    resolution: {integrity: sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==}
+
+  '@emnapi/wasi-threads@1.2.1':
+    resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
 
   '@esbuild-kit/core-utils@3.3.2':
     resolution: {integrity: sha512-sPRAnw9CdSsRmEtnsl2WXWdyquogVpB3yZ3dgwJfe8zrOzTsV7cJvmwrKVa+0ma5BoiGJ+BoqkMvawbayKUsqQ==}
@@ -697,6 +715,12 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@napi-rs/wasm-runtime@1.1.2':
+    resolution: {integrity: sha512-sNXv5oLJ7ob93xkZ1XnxisYhGYXfaG9f65/ZgYuAu3qt7b3NadcOEhLvx28hv31PgX8SZJRYrAIPQilQmFpLVw==}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1
+      '@emnapi/runtime': ^1.7.1
+
   '@rollup/rollup-android-arm-eabi@4.60.1':
     resolution: {integrity: sha512-d6FinEBLdIiK+1uACUttJKfgZREXrF0Qc2SmLII7W2AD8FfiZ9Wjd+rD/iRuf5s5dWrr1GgwXCvPqOuDquOowA==}
     cpu: [arm]
@@ -915,6 +939,97 @@ packages:
     resolution: {integrity: sha512-QGLdC9+pT74Zd7aaObqn0EUfq40c4dyTL65pFnkM6WO1QYN7Yg/s4CdH+CXmx0Zcu6wcfCWILSftXPMosJHP5A==}
     engines: {node: '>=v14.0.0'}
 
+  '@snazzah/davey-android-arm-eabi@0.1.11':
+    resolution: {integrity: sha512-T1RYbNYKN6tLOcGIDKJd8OI6FBSEemwL7DOYdTMmhqfhhMr3YVN8WOhfoxGg63OcnpTN2e2c5tdY2bAx25RmQQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [android]
+
+  '@snazzah/davey-android-arm64@0.1.11':
+    resolution: {integrity: sha512-ksJn/x2VU8h6w9eku1HT96ugSRZ7lKVkKNKbFleaFN+U99DJaPM+gMu2YvnFU4V54HR06ZBnRihnVG6VLXQpDw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [android]
+
+  '@snazzah/davey-darwin-arm64@0.1.11':
+    resolution: {integrity: sha512-E1d7PbaaVMO3Lj9EiAPqOVbuV0xg5+PsHzHH097DDXiD1+zUDXvJaTnUWsnm5z50pJniHpi4GtaYmk+ieB/guA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@snazzah/davey-darwin-x64@0.1.11':
+    resolution: {integrity: sha512-Tl4TI/LTmgJZepgbgVMYDi8RqlAkPtPg1OEBPl7a9Tn3AwR36Vs6lyIT1cs/lGy/ds/+B+mKI4rPObN1cyILTw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@snazzah/davey-freebsd-x64@0.1.11':
+    resolution: {integrity: sha512-T8Iw9FXkuI1T+YBAFzh9v/TXf9IOTOSqnd/BFpTRTrlW72PR2lhIidzSmg027VxO7r5pX47iFwiOkb9I/NU/EA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@snazzah/davey-linux-arm-gnueabihf@0.1.11':
+    resolution: {integrity: sha512-1Txj+8pqA8uq/OGtaUaBFWAPnNMQzFgIywj0iA7EI4xZl+mab48/pv+YZ1pNb/suC6ynsW44oB9efiXSdcUAgA==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [linux]
+
+  '@snazzah/davey-linux-arm64-gnu@0.1.11':
+    resolution: {integrity: sha512-ERzF5nM/IYW1BcN3wLXpEwBCGLFf0kGJUVhaV6yfiInz0tkU8UmvrrgpaMaACfMjIhfWdq5CcX+aTkXo/saNcg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@snazzah/davey-linux-arm64-musl@0.1.11':
+    resolution: {integrity: sha512-e6pX6Hiabtz99q+H/YHNkm9JVlpqN8HGh0qPib8G2+UY4/SSH8WvqWipk3v581dMy2oyCHt7MOoY1aU1P1N/xA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@snazzah/davey-linux-x64-gnu@0.1.11':
+    resolution: {integrity: sha512-TW5bSoqChOJMbvsDb4wAATYrxmAXuNnse7wFNVSAJUaZKSeRfZbu3UAiPWSNn7GwLwSfU6hg322KZUn8IWCuvg==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@snazzah/davey-linux-x64-musl@0.1.11':
+    resolution: {integrity: sha512-5j6Pmc+Wzv5lSxVP6quA7teYRJXibkZqQyYGfTDnTsUOO5dPpcojpqlXlkhyvsA1OAQTj4uxbOCciN3cVWwzug==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@snazzah/davey-wasm32-wasi@0.1.11':
+    resolution: {integrity: sha512-rKOwZ/0J8lp+4VEyOdMDBRP9KR+PksZpa9V1Qn0veMzy4FqTVKthkxwGqewheFe0SFg9fdvt798l/PBFrfDeZw==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+
+  '@snazzah/davey-win32-arm64-msvc@0.1.11':
+    resolution: {integrity: sha512-5fptJU4tX901m3mj0SHiBljMrPT4ZEsynbBhR7bK1yn9TY1jjyhN8EFi7QF5IWtUEni+0mia2BCMHZ5ZkmFZqQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@snazzah/davey-win32-ia32-msvc@0.1.11':
+    resolution: {integrity: sha512-ualexn8SeLsiMHhWfzVrzRcjHgcBapg++FPaVgJJxoh2S/jCRiklXOu3luqIZdJdNKvhe2V9SwO/cImPeIIBKw==}
+    engines: {node: '>= 10'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@snazzah/davey-win32-x64-msvc@0.1.11':
+    resolution: {integrity: sha512-muNhc8UKXtknzsH/w4AIkbPR2I8BuvApn0pDXar0IEvY8PCjqU/M8MPbOOEYwQVvQRMwVTgExtxzrkBPSXB4nA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@snazzah/davey@0.1.11':
+    resolution: {integrity: sha512-oBN+msHzPnm1M5DDx3wVD7iBwpNXFUtkh2MrAbUJu0OhKjliLChi28hq++mu1+qdMpAVQO5JKAvQQxYVbyneiw==}
+    engines: {node: '>= 10'}
+
   '@stencil/core@3.4.2':
     resolution: {integrity: sha512-FAUhUVaakCy29nU2GwO/HQBRV1ihPRvncz3PUc8oR+UJLAxGabTmP8PLY7wvHfbw+Cvi4VXfJFTBvdfDu6iKPQ==}
     engines: {node: '>=14.10.0', npm: '>=6.0.0'}
@@ -922,6 +1037,9 @@ packages:
 
   '@tokenizer/token@0.3.0':
     resolution: {integrity: sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==}
+
+  '@tybys/wasm-util@0.10.1':
+    resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
@@ -1549,6 +1667,13 @@ packages:
   pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
 
+  play-audio@0.5.2:
+    resolution: {integrity: sha512-ZAqHUKkQLix2Iga7pPbsf1LpUoBjcpwU93F1l3qBIfxYddQLhxS6GKmS0d3jV8kSVaUbr6NnOEcEMFvuX93SWQ==}
+
+  play-dl@1.9.7:
+    resolution: {integrity: sha512-KpgerWxUCY4s9Mhze2qdqPhiqd8Ve6HufpH9mBH3FN+vux55qSh6WJKDabfie8IBHN7lnrAlYcT/UdGax58c2A==}
+    engines: {node: '>=16.0.0'}
+
   postcss-load-config@6.0.1:
     resolution: {integrity: sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==}
     engines: {node: '>= 18'}
@@ -1811,6 +1936,9 @@ packages:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
     engines: {node: '>=0.4'}
 
+  youtube-ext@1.1.25:
+    resolution: {integrity: sha512-/TV40aXAQv7hKdwOPOjPKD02kJbfkuwu8IFj9F5OLAetM6NiJ0Sk/sh2IsoL236R1UZgGI9sjcLvKhecYSW5tA==}
+
   zod@4.3.6:
     resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
 
@@ -1936,6 +2064,22 @@ snapshots:
       - utf-8-validate
 
   '@drizzle-team/brocli@0.10.2': {}
+
+  '@emnapi/core@1.9.2':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.1
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/runtime@1.9.2':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.2.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
 
   '@esbuild-kit/core-utils@3.3.2':
     dependencies:
@@ -2205,6 +2349,13 @@ snapshots:
   '@msgpackr-extract/msgpackr-extract-win32-x64@3.0.3':
     optional: true
 
+  '@napi-rs/wasm-runtime@1.1.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)':
+    dependencies:
+      '@emnapi/core': 1.9.2
+      '@emnapi/runtime': 1.9.2
+      '@tybys/wasm-util': 0.10.1
+    optional: true
+
   '@rollup/rollup-android-arm-eabi@4.60.1':
     optional: true
 
@@ -2363,9 +2514,81 @@ snapshots:
 
   '@sapphire/utilities@3.18.2': {}
 
+  '@snazzah/davey-android-arm-eabi@0.1.11':
+    optional: true
+
+  '@snazzah/davey-android-arm64@0.1.11':
+    optional: true
+
+  '@snazzah/davey-darwin-arm64@0.1.11':
+    optional: true
+
+  '@snazzah/davey-darwin-x64@0.1.11':
+    optional: true
+
+  '@snazzah/davey-freebsd-x64@0.1.11':
+    optional: true
+
+  '@snazzah/davey-linux-arm-gnueabihf@0.1.11':
+    optional: true
+
+  '@snazzah/davey-linux-arm64-gnu@0.1.11':
+    optional: true
+
+  '@snazzah/davey-linux-arm64-musl@0.1.11':
+    optional: true
+
+  '@snazzah/davey-linux-x64-gnu@0.1.11':
+    optional: true
+
+  '@snazzah/davey-linux-x64-musl@0.1.11':
+    optional: true
+
+  '@snazzah/davey-wasm32-wasi@0.1.11(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)':
+    dependencies:
+      '@napi-rs/wasm-runtime': 1.1.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+    optional: true
+
+  '@snazzah/davey-win32-arm64-msvc@0.1.11':
+    optional: true
+
+  '@snazzah/davey-win32-ia32-msvc@0.1.11':
+    optional: true
+
+  '@snazzah/davey-win32-x64-msvc@0.1.11':
+    optional: true
+
+  '@snazzah/davey@0.1.11(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)':
+    optionalDependencies:
+      '@snazzah/davey-android-arm-eabi': 0.1.11
+      '@snazzah/davey-android-arm64': 0.1.11
+      '@snazzah/davey-darwin-arm64': 0.1.11
+      '@snazzah/davey-darwin-x64': 0.1.11
+      '@snazzah/davey-freebsd-x64': 0.1.11
+      '@snazzah/davey-linux-arm-gnueabihf': 0.1.11
+      '@snazzah/davey-linux-arm64-gnu': 0.1.11
+      '@snazzah/davey-linux-arm64-musl': 0.1.11
+      '@snazzah/davey-linux-x64-gnu': 0.1.11
+      '@snazzah/davey-linux-x64-musl': 0.1.11
+      '@snazzah/davey-wasm32-wasi': 0.1.11(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
+      '@snazzah/davey-win32-arm64-msvc': 0.1.11
+      '@snazzah/davey-win32-ia32-msvc': 0.1.11
+      '@snazzah/davey-win32-x64-msvc': 0.1.11
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+
   '@stencil/core@3.4.2': {}
 
   '@tokenizer/token@0.3.0': {}
+
+  '@tybys/wasm-util@0.10.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
 
   '@types/estree@1.0.8': {}
 
@@ -2980,6 +3203,12 @@ snapshots:
       mlly: 1.8.2
       pathe: 2.0.3
 
+  play-audio@0.5.2: {}
+
+  play-dl@1.9.7:
+    dependencies:
+      play-audio: 0.5.2
+
   postcss-load-config@6.0.1(tsx@4.21.0):
     dependencies:
       lilconfig: 3.1.3
@@ -3229,5 +3458,9 @@ snapshots:
   ws@8.20.0: {}
 
   xtend@4.0.2: {}
+
+  youtube-ext@1.1.25:
+    dependencies:
+      undici: 6.24.1
 
   zod@4.3.6: {}

--- a/src/commands/music/play.ts
+++ b/src/commands/music/play.ts
@@ -1,5 +1,5 @@
 import { Command } from "@sapphire/framework";
-import { GuildMember } from "discord.js";
+import { EmbedBuilder, GuildMember } from "discord.js";
 import { useMainPlayer } from "discord-player";
 
 export class PlayCommand extends Command {
@@ -32,7 +32,7 @@ export class PlayCommand extends Command {
 		await interaction.deferReply();
 
 		try {
-			const { track } = await player.play(voiceChannel, query, {
+			const { track, searchResult } = await player.play(voiceChannel, query, {
 				nodeOptions: {
 					metadata: {
 						channel: interaction.channel,
@@ -47,6 +47,29 @@ export class PlayCommand extends Command {
 				},
 				requestedBy: interaction.user,
 			});
+
+			if (searchResult.hasPlaylist() && searchResult.playlist) {
+				const playlist = searchResult.playlist;
+				const tracks = searchResult.tracks;
+				const isSpotify = query.includes("open.spotify.com");
+				const color = isSpotify ? 0x1db954 : 0xff0000;
+
+				const trackList = tracks
+					.slice(0, 5)
+					.map((t, i) => `${i + 1}. **${t.title}** — ${t.author}`)
+					.join("\n");
+
+				const embed = new EmbedBuilder()
+					.setColor(color)
+					.setTitle(playlist.title)
+					.setURL(playlist.url || null)
+					.setDescription(trackList)
+					.setFooter({
+						text: `Queued by ${interaction.user.username} · ${tracks.length} tracks`,
+					});
+
+				return interaction.editReply({ embeds: [embed] });
+			}
 
 			return interaction.editReply({ content: `Queued: **${track.title}** by **${track.author}**` });
 		} catch (error) {


### PR DESCRIPTION
## Summary
- Install `youtube-ext` and `play-dl` bridge libraries so `YoutubeExtractor` and `SpotifyExtractor` (already registered via `DefaultExtractors`) actually work
- Update `/play` command to show a rich embed when a playlist is queued (YouTube red or Spotify green), listing the first 5 tracks, total count, and requester
- Single-track and search query responses are unchanged

## Test Plan
- [ ] `/play never gonna give you up` → plain text: `Queued: Never Gonna Give You Up by Rick Astley`
- [ ] `/play https://www.youtube.com/watch?v=dQw4w9WgXcQ` → plain text single-track response
- [ ] `/play https://www.youtube.com/playlist?list=<public playlist>` → red embed with playlist name, first 5 tracks, footer with track count
- [ ] `/play https://open.spotify.com/playlist/<id>` → green embed with playlist name, first 5 tracks, footer with track count