### PR TITLE
feat: add 10-minute per-trigger cooldown to auto-responder

### DIFF
--- a/src/listeners/messages/messageCreate.ts
+++ b/src/listeners/messages/messageCreate.ts
@@ -11,6 +11,10 @@ import type { BhayanakClient } from "../../lib/BhayanakClient.js";
 // Spam tracking: Map<guildId:userId, { count, resetAt }>
 const spamTracker = new Map<string, { count: number; resetAt: number }>();
 
+// Auto-responder cooldown: Map<guildId:trigger, lastFiredAt>
+const autoResponderCooldown = new Map<string, number>();
+const AUTO_RESPONDER_COOLDOWN_MS = 10 * 60 * 1000; // 10 minutes
+
 const BAD_LINK_PATTERN = /https?:\/\/(discord\.gg|discordapp\.com\/invite|bit\.ly|tinyurl\.com)\//i;
 
 export class MessageCreateListener extends Listener {
@@ -100,12 +104,22 @@ export class MessageCreateListener extends Listener {
 		const match = await findMatchingResponse(message.guild.id, message.content);
 		this.container.logger.debug(`[autoresponder] guild=${message.guild.id} content="${message.content.slice(0, 50)}" match=${match ? `trigger="${match.trigger}" type=${match.responseType}` : "none"}`);
 		if (match) {
-			if (match.responseType === "llm") {
-				const reply = await generateAutoResponse(match.response, message.content, message.author.username);
-				this.container.logger.debug(`[autoresponder] LLM reply=${reply ? `"${reply.slice(0, 50)}"` : "null (skipping)"}`);
-				if (reply) await (message.channel as TextChannel).send(reply).catch(() => null);
+			const cooldownKey = `${message.guild.id}:${match.trigger}`;
+			const lastFired = autoResponderCooldown.get(cooldownKey) ?? 0;
+			const botMentioned = message.mentions.has(message.client.user);
+			const onCooldown = Date.now() - lastFired < AUTO_RESPONDER_COOLDOWN_MS;
+
+			if (onCooldown && !botMentioned) {
+				this.container.logger.debug(`[autoresponder] trigger="${match.trigger}" skipped (cooldown)`);
 			} else {
-				await (message.channel as TextChannel).send(match.response).catch(() => null);
+				autoResponderCooldown.set(cooldownKey, Date.now());
+				if (match.responseType === "llm") {
+					const reply = await generateAutoResponse(match.response, message.content, message.author.username);
+					this.container.logger.debug(`[autoresponder] LLM reply=${reply ? `"${reply.slice(0, 50)}"` : "null (skipping)"}`);
+					if (reply) await (message.channel as TextChannel).send(reply).catch(() => null);
+				} else {
+					await (message.channel as TextChannel).send(match.response).catch(() => null);
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

- Adds a 10-minute per-trigger cooldown to the trigger-word auto-responder
- Each trigger has an independent cooldown scoped to the guild (`guildId:trigger` key)
- Cooldown is bypassed when the bot is @mentioned in the triggering message

## Test plan

- [ ] Send a message matching a trigger — bot responds
- [ ] Send the same trigger again within 10 minutes — bot stays silent
- [ ] Send the same trigger again within 10 minutes while @mentioning the bot — bot responds
- [ ] Verify different triggers are independent (one on cooldown doesn't block others)

🤖 Generated with [Claude Code](https://claude.com/claude-code)