### PR TITLE
fix: increase REST timeout to prevent portrait command AbortError

### DIFF
--- a/src/lib/BhayanakClient.ts
+++ b/src/lib/BhayanakClient.ts
@@ -44,6 +44,9 @@ export class BhayanakClient extends SapphireClient {
 	public constructor() {
 		const valkeyUrl = new URL(process.env.VALKEY_URL ?? "redis://localhost:6379");
 		super({
+			// Increase REST timeout to 60s to accommodate long-running operations like portrait image generation.
+			// This applies globally to ALL Discord REST calls (editReply, send, etc.).
+			rest: { timeout: 60_000 },
 			intents: [
 				GatewayIntentBits.Guilds,
 				GatewayIntentBits.GuildMembers,

--- a/src/lib/imageGen.ts
+++ b/src/lib/imageGen.ts
@@ -7,6 +7,7 @@ export async function generateImage(prompt: string): Promise<Buffer | null> {
 		const res = await fetch(`${SD_URL}/sdapi/v1/txt2img`, {
 			method: "POST",
 			headers: { "Content-Type": "application/json" },
+			signal: AbortSignal.timeout(5 * 60_000), // 5-minute timeout for CPU generation
 			body: JSON.stringify({
 				prompt,
 				negative_prompt: "ugly, blurry, low quality, deformed, nsfw",


### PR DESCRIPTION
## Summary
- `/portrait` command was failing with `DOMException [AbortError]` because stable diffusion image generation (~24s on CPU) caused the Discord REST client to abort
- Increased global REST timeout from default 15s to 60s in `BhayanakClient`
- Added a 5-minute `AbortSignal.timeout` to the stable diffusion `fetch` in `imageGen.ts` to prevent indefinite hangs

## Root Cause
`@discordjs/rest` has a default 15-second per-request HTTP timeout. The SD generation blocked the command for ~24s, after which `editReply` was aborted before it could complete.

## Test plan
- [ ] Run `/portrait` command and confirm it completes without `AbortError`
- [ ] Confirm the generated portrait image appears in Discord
- [ ] Confirm the portrait CDN URL is saved and cooldown is set

🤖 Generated with [Claude Code](https://claude.com/claude-code)