### PR TITLE
feat: @mention user in auto-responder replies

### DIFF
--- a/src/listeners/messages/messageCreate.ts
+++ b/src/listeners/messages/messageCreate.ts
@@ -116,9 +116,9 @@ export class MessageCreateListener extends Listener {
 				if (match.responseType === "llm") {
 					const reply = await generateAutoResponse(match.response, message.content, message.author.username);
 					this.container.logger.debug(`[autoresponder] LLM reply=${reply ? `"${reply.slice(0, 50)}"` : "null (skipping)"}`);
-					if (reply) await (message.channel as TextChannel).send(reply).catch(() => null);
+					if (reply) await message.reply(reply).catch(() => null);
 				} else {
-					await (message.channel as TextChannel).send(match.response).catch(() => null);
+					await message.reply(match.response).catch(() => null);
 				}
 			}
 		}


### PR DESCRIPTION
## Summary
- Switch auto-responder from `channel.send()` to `message.reply()` in both LLM and static response paths
- Bot now pings the triggering user and shows a message reference instead of sending a plain channel message

## Test plan
- [ ] Trigger an LLM auto-responder — bot reply should @mention you and show a message reference
- [ ] Trigger a static auto-responder — same behaviour

🤖 Generated with [Claude Code](https://claude.com/claude-code)