### PR TITLE
fix: catch HTTP/2 stream errors on file-upload editReply

### DIFF
--- a/src/commands/fun/pfp-edit.ts
+++ b/src/commands/fun/pfp-edit.ts
@@ -160,7 +160,18 @@ export class PfpEditCommand extends Command {
 			.setImage("attachment://pfp-edit.png")
 			.setFooter({ text: `Requested by ${interaction.user.displayName}` });
 
-		await interaction.editReply({ embeds: [embed], files: [attachment] });
+		try {
+			await interaction.editReply({ embeds: [embed], files: [attachment] });
+		} catch {
+			// HTTP/2 connection to Discord may have gone stale during long image generation.
+			return interaction.editReply({
+				embeds: [
+					new EmbedBuilder()
+						.setColor(0xed4245)
+						.setDescription("Image was generated but failed to upload to Discord. Please try again."),
+				],
+			});
+		}
 
 		await setCooldown(interaction.user.id, "pfp-edit", USER_COOLDOWN_MS);
 		if (!isSelf) {

--- a/src/commands/rpg/portrait.ts
+++ b/src/commands/rpg/portrait.ts
@@ -72,7 +72,21 @@ export class PortraitCommand extends Command {
 			.setImage("attachment://portrait.png")
 			.setFooter({ text: "Next portrait available in 7 days" });
 
-		const reply = await interaction.editReply({ embeds: [embed], files: [attachment] });
+		let reply: Awaited<ReturnType<typeof interaction.editReply>>;
+		try {
+			reply = await interaction.editReply({ embeds: [embed], files: [attachment] });
+		} catch {
+			// HTTP/2 connection to Discord may have gone stale during long image generation.
+			// Retry once without the file to at least inform the user.
+			return interaction.editReply({
+				embeds: [
+					new EmbedBuilder()
+						.setColor(0xed4245)
+						.setTitle("🎨 Upload Failed")
+						.setDescription("Portrait was generated but failed to upload to Discord. Please try the command again."),
+				],
+			});
+		}
 
 		// Save the CDN URL from the reply attachment
 		const attachmentUrl = reply.attachments.first()?.url;


### PR DESCRIPTION
## Summary

- After CPU image generation (can take several minutes), the HTTP/2 connection Discord.js holds to Discord's API goes stale/reset by Discord's servers
- The final `editReply({ files: [attachment] })` call throws `ERR_HTTP2_STREAM_ERROR: NGHTTP2_PROTOCOL_ERROR` when it tries to reuse the dead connection
- Neither `portrait.ts` nor `pfp-edit.ts` wrapped this call in try-catch, so the error propagated to Sapphire's top-level handler

## Fix

Wrapped the file-upload `editReply` in a try-catch in both commands. On failure, an error embed is shown to the user. In `portrait.ts`, the cooldown is not set on failure so the user can retry immediately.

## Test plan

- [ ] Run `/portrait` and verify it no longer crashes with `ERR_HTTP2_STREAM_ERROR` after image generation
- [ ] Run `/pfp-edit` and verify same
- [ ] If SD is slow, confirm the error embed is shown gracefully instead of a silent Sapphire error

🤖 Generated with [Claude Code](https://claude.com/claude-code)