### PR TITLE
fix: increase summarize timeout and let model decide bullet count

### DIFF
--- a/src/commands/utility/summarize.ts
+++ b/src/commands/utility/summarize.ts
@@ -4,10 +4,11 @@ import { callOllama } from "../../lib/ollama.js";
 
 const COOLDOWN_MS = 10 * 60 * 1000;
 const MAX_MESSAGES = 200;
-const OLLAMA_TIMEOUT_MS = 30_000;
+const OLLAMA_TIMEOUT_MS = 300_000;
 
 const SYSTEM_PROMPT = [
-	"You are a helpful assistant. Summarize the following Discord chat conversation concisely in 3-6 bullet points.",
+	"You are a helpful assistant. Summarize the following Discord chat conversation concisely in bullet points.",
+	"Use as many bullet points as needed to capture the conversation — fewer for short chats, more for long ones.",
 	"Focus on key topics, decisions, and notable moments.",
 	"Do not use quotation marks. Do not include greetings or preamble.",
 ].join(" ");


### PR DESCRIPTION
## Summary
- Bumps Ollama timeout from 30s to 300s to handle CPU-constrained inference with `llama3.1:8b`
- Updates system prompt to let the model scale bullet points to conversation size instead of a fixed 3-6

## Test plan
- [ ] Run `/summarize` and confirm it completes without aborting on a CPU-constrained Ollama instance
- [ ] Verify short conversations produce fewer bullets and long ones produce more

🤖 Generated with [Claude Code](https://claude.com/claude-code)