### PR TITLE
feat: add personality profiling system

### DIFF
--- a/drizzle/0005_chunky_triathlon.sql
+++ b/drizzle/0005_chunky_triathlon.sql
@@ -1,0 +1,18 @@
+CREATE TABLE "user_messages" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"user_id" varchar(20) NOT NULL,
+	"guild_id" varchar(20) NOT NULL,
+	"content" text NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX "idx_user_messages_user_guild" ON "user_messages" ("user_id","guild_id");
+--> statement-breakpoint
+CREATE TABLE "user_personality_profiles" (
+	"user_id" varchar(20) NOT NULL,
+	"guild_id" varchar(20) NOT NULL,
+	"profile" text,
+	"new_message_count" integer DEFAULT 0 NOT NULL,
+	"last_refreshed_at" timestamp,
+	CONSTRAINT "user_personality_profiles_user_id_guild_id_pk" PRIMARY KEY("user_id","guild_id")
+);

--- a/drizzle/meta/0005_snapshot.json
+++ b/drizzle/meta/0005_snapshot.json
@@ -1,0 +1,1744 @@
+{
+  "id": "4b676914-92e5-47b4-b662-ed63aac20260",
+  "prevId": "88b48e18-45f8-495a-a264-0680fd0e26f6",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.afk_users": {
+      "name": "afk_users",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guild_id": {
+          "name": "guild_id",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "set_at": {
+          "name": "set_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auto_responses": {
+      "name": "auto_responses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "guild_id": {
+          "name": "guild_id",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "response": {
+          "name": "response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "match_type": {
+          "name": "match_type",
+          "type": "auto_response_match_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'contains'"
+        },
+        "response_type": {
+          "name": "response_type",
+          "type": "auto_response_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'static'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.daily_quests": {
+      "name": "daily_quests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "guild_id": {
+          "name": "guild_id",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "objective_type": {
+          "name": "objective_type",
+          "type": "quest_objective_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "objective_job": {
+          "name": "objective_job",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "objective_count": {
+          "name": "objective_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "reward_coins": {
+          "name": "reward_coins",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 500
+        },
+        "reward_xp": {
+          "name": "reward_xp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "date": {
+          "name": "date",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.giveaways": {
+      "name": "giveaways",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guild_id": {
+          "name": "guild_id",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prize": {
+          "name": "prize",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "winner_count": {
+          "name": "winner_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "ends_at": {
+          "name": "ends_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ended": {
+          "name": "ended",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "host_id": {
+          "name": "host_id",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "winners": {
+          "name": "winners",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "entries": {
+          "name": "entries",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.guild_settings": {
+      "name": "guild_settings",
+      "schema": "",
+      "columns": {
+        "guild_id": {
+          "name": "guild_id",
+          "type": "varchar(20)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "welcome_channel_id": {
+          "name": "welcome_channel_id",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "goodbye_channel_id": {
+          "name": "goodbye_channel_id",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "log_channel_id": {
+          "name": "log_channel_id",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "level_up_channel_id": {
+          "name": "level_up_channel_id",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "music_channel_id": {
+          "name": "music_channel_id",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "starboard_channel_id": {
+          "name": "starboard_channel_id",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ticket_category_id": {
+          "name": "ticket_category_id",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_role": {
+          "name": "auto_role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "muted_role_id": {
+          "name": "muted_role_id",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ticket_support_role_id": {
+          "name": "ticket_support_role_id",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dj_role_id": {
+          "name": "dj_role_id",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "moderator_role_id": {
+          "name": "moderator_role_id",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "welcome_message": {
+          "name": "welcome_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "goodbye_message": {
+          "name": "goodbye_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "level_up_message": {
+          "name": "level_up_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "star_threshold": {
+          "name": "star_threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 3
+        },
+        "xp_rate": {
+          "name": "xp_rate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 15
+        },
+        "xp_cooldown_seconds": {
+          "name": "xp_cooldown_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 60
+        },
+        "auto_mod_enabled": {
+          "name": "auto_mod_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "auto_mod_spam_threshold": {
+          "name": "auto_mod_spam_threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 5
+        },
+        "auto_mod_bad_links": {
+          "name": "auto_mod_bad_links",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "auto_mod_max_mentions": {
+          "name": "auto_mod_max_mentions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 5
+        },
+        "auto_mod_action": {
+          "name": "auto_mod_action",
+          "type": "auto_mod_action",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'warn'"
+        },
+        "auto_mod_mute_duration": {
+          "name": "auto_mod_mute_duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 300000
+        },
+        "anti_raid_enabled": {
+          "name": "anti_raid_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "anti_raid_join_threshold": {
+          "name": "anti_raid_join_threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 10
+        },
+        "anti_raid_join_window": {
+          "name": "anti_raid_join_window",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 10
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.level_rewards": {
+      "name": "level_rewards",
+      "schema": "",
+      "columns": {
+        "guild_id": {
+          "name": "guild_id",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "level": {
+          "name": "level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "level_rewards_guild_id_level_pk": {
+          "name": "level_rewards_guild_id_level_pk",
+          "columns": [
+            "guild_id",
+            "level"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mod_cases": {
+      "name": "mod_cases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "case_number": {
+          "name": "case_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guild_id": {
+          "name": "guild_id",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "moderator_id": {
+          "name": "moderator_id",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "mod_case_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pet_portraits": {
+      "name": "pet_portraits",
+      "schema": "",
+      "columns": {
+        "pet_id": {
+          "name": "pet_id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.polls": {
+      "name": "polls",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guild_id": {
+          "name": "guild_id",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question": {
+          "name": "question",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "options": {
+          "name": "options",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "closed": {
+          "name": "closed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.quest_progress": {
+      "name": "quest_progress",
+      "schema": "",
+      "columns": {
+        "quest_id": {
+          "name": "quest_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guild_id": {
+          "name": "guild_id",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "progress": {
+          "name": "progress",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "quest_progress_quest_id_user_id_pk": {
+          "name": "quest_progress_quest_id_user_id_pk",
+          "columns": [
+            "quest_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reaction_roles": {
+      "name": "reaction_roles",
+      "schema": "",
+      "columns": {
+        "message_id": {
+          "name": "message_id",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guild_id": {
+          "name": "guild_id",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "reaction_role_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'normal'"
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "reaction_roles_message_id_emoji_pk": {
+          "name": "reaction_roles_message_id_emoji_pk",
+          "columns": [
+            "message_id",
+            "emoji"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reminders": {
+      "name": "reminders",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guild_id": {
+          "name": "guild_id",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "remind_at": {
+          "name": "remind_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sent": {
+          "name": "sent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.role_menu_options": {
+      "name": "role_menu_options",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "menu_id": {
+          "name": "menu_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.role_menus": {
+      "name": "role_menus",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guild_id": {
+          "name": "guild_id",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "placeholder": {
+          "name": "placeholder",
+          "type": "varchar(150)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "min_values": {
+          "name": "min_values",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "max_values": {
+          "name": "max_values",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rpg_cooldowns": {
+      "name": "rpg_cooldowns",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "rpg_cooldowns_user_id_action_pk": {
+          "name": "rpg_cooldowns_user_id_action_pk",
+          "columns": [
+            "user_id",
+            "action"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rpg_inventory": {
+      "name": "rpg_inventory",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "equipped_slot": {
+          "name": "equipped_slot",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rpg_owned_pets": {
+      "name": "rpg_owned_pets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pet_id": {
+          "name": "pet_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nickname": {
+          "name": "nickname",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "acquired_at": {
+          "name": "acquired_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rpg_owned_properties": {
+      "name": "rpg_owned_properties",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "property_id": {
+          "name": "property_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "purchased_at": {
+          "name": "purchased_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_collected_at": {
+          "name": "last_collected_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "rpg_owned_properties_user_id_property_id_unique": {
+          "name": "rpg_owned_properties_user_id_property_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "property_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rpg_profiles": {
+      "name": "rpg_profiles",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(20)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "coins": {
+          "name": "coins",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "level": {
+          "name": "level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "xp": {
+          "name": "xp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "jail_until": {
+          "name": "jail_until",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "jail_bail_cost": {
+          "name": "jail_bail_cost",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "portrait_url": {
+          "name": "portrait_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rpg_stats": {
+      "name": "rpg_stats",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(20)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "strength": {
+          "name": "strength",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "intelligence": {
+          "name": "intelligence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "agility": {
+          "name": "agility",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "charisma": {
+          "name": "charisma",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "luck": {
+          "name": "luck",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "str_trained_at": {
+          "name": "str_trained_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "int_trained_at": {
+          "name": "int_trained_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agi_trained_at": {
+          "name": "agi_trained_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cha_trained_at": {
+          "name": "cha_trained_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "luk_trained_at": {
+          "name": "luk_trained_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.starred_messages": {
+      "name": "starred_messages",
+      "schema": "",
+      "columns": {
+        "message_id": {
+          "name": "message_id",
+          "type": "varchar(20)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "starboard_message_id": {
+          "name": "starboard_message_id",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guild_id": {
+          "name": "guild_id",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "star_count": {
+          "name": "star_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.suggestions": {
+      "name": "suggestions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guild_id": {
+          "name": "guild_id",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "suggestion_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "response": {
+          "name": "response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tickets": {
+      "name": "tickets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guild_id": {
+          "name": "guild_id",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "ticket_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "claimed_by": {
+          "name": "claimed_by",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transcript_url": {
+          "name": "transcript_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closed_by": {
+          "name": "closed_by",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_messages": {
+      "name": "user_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guild_id": {
+          "name": "guild_id",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_personality_profiles": {
+      "name": "user_personality_profiles",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guild_id": {
+          "name": "guild_id",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile": {
+          "name": "profile",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_message_count": {
+          "name": "new_message_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_refreshed_at": {
+          "name": "last_refreshed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "user_personality_profiles_user_id_guild_id_pk": {
+          "name": "user_personality_profiles_user_id_guild_id_pk",
+          "columns": [
+            "user_id",
+            "guild_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guild_id": {
+          "name": "guild_id",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "xp": {
+          "name": "xp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "level": {
+          "name": "level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_messages": {
+          "name": "total_messages",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_message_at": {
+          "name": "last_message_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "users_user_id_guild_id_pk": {
+          "name": "users_user_id_guild_id_pk",
+          "columns": [
+            "user_id",
+            "guild_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.auto_mod_action": {
+      "name": "auto_mod_action",
+      "schema": "public",
+      "values": [
+        "warn",
+        "mute",
+        "kick"
+      ]
+    },
+    "public.auto_response_match_type": {
+      "name": "auto_response_match_type",
+      "schema": "public",
+      "values": [
+        "exact",
+        "contains",
+        "startsWith"
+      ]
+    },
+    "public.auto_response_type": {
+      "name": "auto_response_type",
+      "schema": "public",
+      "values": [
+        "static",
+        "llm"
+      ]
+    },
+    "public.mod_case_type": {
+      "name": "mod_case_type",
+      "schema": "public",
+      "values": [
+        "warn",
+        "mute",
+        "unmute",
+        "kick",
+        "ban",
+        "unban",
+        "tempban"
+      ]
+    },
+    "public.quest_objective_type": {
+      "name": "quest_objective_type",
+      "schema": "public",
+      "values": [
+        "work",
+        "crime",
+        "train"
+      ]
+    },
+    "public.reaction_role_type": {
+      "name": "reaction_role_type",
+      "schema": "public",
+      "values": [
+        "normal",
+        "toggle",
+        "unique"
+      ]
+    },
+    "public.suggestion_status": {
+      "name": "suggestion_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "approved",
+        "denied"
+      ]
+    },
+    "public.ticket_status": {
+      "name": "ticket_status",
+      "schema": "public",
+      "values": [
+        "open",
+        "closed"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1775468298894,
       "tag": "0004_strange_silverclaw",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1775833022399,
+      "tag": "0005_chunky_triathlon",
+      "breakpoints": true
     }
   ]
 }

--- a/src/commands/rpg/crime.ts
+++ b/src/commands/rpg/crime.ts
@@ -22,6 +22,8 @@ import { getRemainingCooldown, formatDuration } from "../../lib/rpg/helpers/cool
 import { JOBS, getJob } from "../../lib/rpg/catalogs/jobs.js";
 import { ITEMS } from "../../lib/rpg/catalogs/items.js";
 import { generateFlavorText } from "../../lib/rpg/helpers/flavorText.js";
+import { getPersonalityContext } from "../../lib/personality/getPersonalityContext.js";
+import type { BhayanakClient } from "../../lib/BhayanakClient.js";
 
 const CRIME_CHOICES = Object.values(JOBS)
 	.filter((j) => j.category === "crime")
@@ -88,6 +90,9 @@ export class CrimeCommand extends Command {
 
 		const { profile, stats } = await getOrCreateProfile(interaction.user.id);
 		const activePet = await getActivePet(interaction.user.id);
+		const personalityCtx = interaction.guildId
+			? await getPersonalityContext(interaction.client as BhayanakClient, interaction.user.id, interaction.guildId)
+			: "";
 
 		if (isInJail(profile)) {
 			const until = Math.floor(profile.jailUntil!.getTime() / 1000);
@@ -185,6 +190,7 @@ export class CrimeCommand extends Command {
 				petName: activePet?.nickname ?? activePet?.petId,
 				petType: activePet?.petId,
 				activeItem: hasCharm ? "lucky charm" : undefined,
+				personalityContext: personalityCtx,
 			});
 
 			await interaction.editReply({
@@ -245,6 +251,7 @@ export class CrimeCommand extends Command {
 				playerLevel: profile.level,
 				petName: activePet?.nickname ?? activePet?.petId,
 				petType: activePet?.petId,
+				personalityContext: personalityCtx,
 			});
 
 			return interaction.editReply({

--- a/src/commands/rpg/work.ts
+++ b/src/commands/rpg/work.ts
@@ -18,6 +18,8 @@ import { getRemainingCooldown, formatDuration } from "../../lib/rpg/helpers/cool
 import { JOBS, getJob } from "../../lib/rpg/catalogs/jobs.js";
 import { ITEMS } from "../../lib/rpg/catalogs/items.js";
 import { generateFlavorText } from "../../lib/rpg/helpers/flavorText.js";
+import { getPersonalityContext } from "../../lib/personality/getPersonalityContext.js";
+import type { BhayanakClient } from "../../lib/BhayanakClient.js";
 
 const JOB_CHOICES = Object.values(JOBS)
 	.filter((j) => j.category !== "crime")
@@ -58,6 +60,9 @@ export class WorkCommand extends Command {
 
 		const { profile, stats } = await getOrCreateProfile(interaction.user.id);
 		const activePet = await getActivePet(interaction.user.id);
+		const personalityCtx = interaction.guildId
+			? await getPersonalityContext(interaction.client as BhayanakClient, interaction.user.id, interaction.guildId)
+			: "";
 
 		if (isInJail(profile)) {
 			const until = Math.floor(profile.jailUntil!.getTime() / 1000);
@@ -140,6 +145,7 @@ export class WorkCommand extends Command {
 				petName: activePet?.nickname ?? activePet?.petId,
 				petType: activePet?.petId,
 				activeItem: hasCharm ? "lucky charm" : undefined,
+				personalityContext: personalityCtx,
 			});
 
 			await interaction.editReply({
@@ -175,6 +181,7 @@ export class WorkCommand extends Command {
 				playerLevel: profile.level,
 				petName: activePet?.nickname ?? activePet?.petId,
 				petType: activePet?.petId,
+				personalityContext: personalityCtx,
 			});
 
 			return interaction.editReply({

--- a/src/commands/utility/personality.ts
+++ b/src/commands/utility/personality.ts
@@ -1,0 +1,59 @@
+import { Command } from "@sapphire/framework";
+import { EmbedBuilder } from "discord.js";
+import { getPersonalityProfile } from "../../db/queries/personality.js";
+
+const FIELD_LIMIT = 1024;
+
+export class PersonalityCommand extends Command {
+	public constructor(context: Command.LoaderContext, options: Command.Options) {
+		super(context, { ...options, preconditions: ["GuildOnly", "IsAdmin"] });
+	}
+
+	public override registerApplicationCommands(registry: Command.Registry) {
+		registry.registerChatInputCommand((builder) =>
+			builder
+				.setName("personality")
+				.setDescription("View the bot's personality profile for a user (admin only)")
+				.addUserOption((opt) => opt.setName("user").setDescription("User to look up (defaults to yourself)").setRequired(false)),
+		);
+	}
+
+	public override async chatInputRun(interaction: Command.ChatInputCommandInteraction) {
+		await interaction.deferReply({ ephemeral: true });
+
+		const target = interaction.options.getUser("user") ?? interaction.user;
+		const guildId = interaction.guildId!;
+
+		const profile = await getPersonalityProfile(target.id, guildId);
+
+		if (!profile) {
+			return interaction.editReply({
+				embeds: [
+					new EmbedBuilder()
+						.setColor(0xfee75c)
+						.setTitle(`Personality Profile — ${target.displayName}`)
+						.setDescription("No personality profile exists for this user yet. The bot needs more messages to build one."),
+				],
+			});
+		}
+
+		const embed = new EmbedBuilder()
+			.setColor(0x5865f2)
+			.setTitle(`Personality Profile — ${target.displayName}`)
+			.setThumbnail(target.displayAvatarURL({ size: 128 }));
+
+		// Split profile into chunks that fit Discord's field value limit
+		const chunks: string[] = [];
+		let remaining = profile;
+		while (remaining.length > 0) {
+			chunks.push(remaining.slice(0, FIELD_LIMIT));
+			remaining = remaining.slice(FIELD_LIMIT);
+		}
+
+		for (let i = 0; i < chunks.length; i++) {
+			embed.addFields({ name: i === 0 ? "Profile" : "\u200b", value: chunks[i] });
+		}
+
+		return interaction.editReply({ embeds: [embed] });
+	}
+}

--- a/src/db/queries/personality.ts
+++ b/src/db/queries/personality.ts
@@ -1,0 +1,66 @@
+import { and, eq, inArray, lt, or, sql } from "drizzle-orm";
+import { db } from "../../lib/database.js";
+import { userMessages, userPersonalityProfiles } from "../schema.js";
+
+export async function storeUserMessage(userId: string, guildId: string, content: string): Promise<void> {
+	await db.insert(userMessages).values({ userId, guildId, content });
+}
+
+export async function getUnabsorbedMessages(userId: string, guildId: string): Promise<{ id: number; content: string }[]> {
+	return db.query.userMessages.findMany({
+		where: and(eq(userMessages.userId, userId), eq(userMessages.guildId, guildId)),
+		columns: { id: true, content: true },
+	});
+}
+
+export async function deleteAbsorbedMessages(ids: number[]): Promise<void> {
+	if (ids.length === 0) return;
+	await db.delete(userMessages).where(inArray(userMessages.id, ids));
+}
+
+export async function getPersonalityProfile(userId: string, guildId: string): Promise<string | null> {
+	const row = await db.query.userPersonalityProfiles.findFirst({
+		where: and(eq(userPersonalityProfiles.userId, userId), eq(userPersonalityProfiles.guildId, guildId)),
+		columns: { profile: true },
+	});
+	return row?.profile ?? null;
+}
+
+export async function upsertPersonalityProfile(userId: string, guildId: string, profile: string): Promise<void> {
+	await db
+		.insert(userPersonalityProfiles)
+		.values({ userId, guildId, profile, newMessageCount: 0, lastRefreshedAt: new Date() })
+		.onConflictDoUpdate({
+			target: [userPersonalityProfiles.userId, userPersonalityProfiles.guildId],
+			set: { profile, newMessageCount: 0, lastRefreshedAt: new Date() },
+		});
+}
+
+/** Increments newMessageCount and returns the updated count. Creates the profile row if it doesn't exist. */
+export async function incrementMessageCount(userId: string, guildId: string): Promise<number> {
+	const [row] = await db
+		.insert(userPersonalityProfiles)
+		.values({ userId, guildId, newMessageCount: 1 })
+		.onConflictDoUpdate({
+			target: [userPersonalityProfiles.userId, userPersonalityProfiles.guildId],
+			set: { newMessageCount: sql`${userPersonalityProfiles.newMessageCount} + 1` },
+		})
+		.returning({ newMessageCount: userPersonalityProfiles.newMessageCount });
+	return row.newMessageCount;
+}
+
+/** Returns users who have unabsorbed messages AND (count >= 100 OR last refresh > 6h ago OR never refreshed). */
+export async function getUsersNeedingRefresh(): Promise<{ userId: string; guildId: string }[]> {
+	const sixHoursAgo = new Date(Date.now() - 6 * 60 * 60 * 1000);
+	return db.query.userPersonalityProfiles.findMany({
+		where: and(
+			sql`${userPersonalityProfiles.newMessageCount} > 0`,
+			or(
+				sql`${userPersonalityProfiles.newMessageCount} >= 100`,
+				eq(userPersonalityProfiles.lastRefreshedAt, null as unknown as Date),
+				lt(userPersonalityProfiles.lastRefreshedAt, sixHoursAgo),
+			),
+		),
+		columns: { userId: true, guildId: true },
+	});
+}

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -209,6 +209,28 @@ export const autoResponses = pgTable("auto_responses", {
 	createdAt: timestamp("created_at").defaultNow().notNull(),
 });
 
+// --- Personality Profiling ---
+
+export const userMessages = pgTable("user_messages", {
+	id: serial("id").primaryKey(),
+	userId: varchar("user_id", { length: 20 }).notNull(),
+	guildId: varchar("guild_id", { length: 20 }).notNull(),
+	content: text("content").notNull(),
+	createdAt: timestamp("created_at").defaultNow().notNull(),
+});
+
+export const userPersonalityProfiles = pgTable(
+	"user_personality_profiles",
+	{
+		userId: varchar("user_id", { length: 20 }).notNull(),
+		guildId: varchar("guild_id", { length: 20 }).notNull(),
+		profile: text("profile"),
+		newMessageCount: integer("new_message_count").default(0).notNull(),
+		lastRefreshedAt: timestamp("last_refreshed_at"),
+	},
+	(t) => [primaryKey({ columns: [t.userId, t.guildId] })],
+);
+
 // --- RPG Module ---
 
 export const rpgProfiles = pgTable("rpg_profiles", {

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,6 +33,7 @@ async function main() {
 		await client.stores.get("scheduled-tasks").get("endPolls")?.run(null as never);
 		await client.stores.get("scheduled-tasks").get("reloadOnRestart")?.run(null as never);
 		await client.stores.get("scheduled-tasks").get("generateDailyQuests")?.run(null as never);
+		await client.stores.get("scheduled-tasks").get("refreshPersonalityProfiles")?.run(null as never);
 
 		// Schedule interval runs (every 30 seconds)
 		const tasks = ["expireMutes", "expireTempBans", "sendReminders", "endGiveaways", "endPolls"] as const;
@@ -50,6 +51,20 @@ async function main() {
 				}
 			}, 30_000);
 		}
+
+		// Refresh personality profiles every 6 hours
+		let personalityTaskRunning = false;
+		setInterval(async () => {
+			if (personalityTaskRunning) return;
+			personalityTaskRunning = true;
+			try {
+				await client.stores.get("scheduled-tasks").get("refreshPersonalityProfiles")?.run(null as never);
+			} catch (err) {
+				client.logger.error("[ScheduledTask:refreshPersonalityProfiles] Error:", err);
+			} finally {
+				personalityTaskRunning = false;
+			}
+		}, 6 * 60 * 60 * 1000);
 
 		// Check once per hour — task is idempotent, skips if quests already exist for today
 		let questTaskRunning = false;

--- a/src/lib/BhayanakClient.ts
+++ b/src/lib/BhayanakClient.ts
@@ -40,6 +40,8 @@ export class BhayanakClient extends SapphireClient {
 	public readonly editSnipeCache = new BoundedMap<string, EditSnipedMessage>(1000);
 	// Anti-raid: track recent joins per guild
 	public readonly recentJoins = new Map<string, number[]>();
+	// Personality profile cache keyed by "userId:guildId"
+	public readonly personalityCache = new BoundedMap<string, string>(500);
 
 	public constructor() {
 		const valkeyUrl = new URL(process.env.VALKEY_URL ?? "redis://localhost:6379");
@@ -81,5 +83,6 @@ declare module "@sapphire/framework" {
 		snipeCache: BoundedMap<string, SnipedMessage>;
 		editSnipeCache: BoundedMap<string, EditSnipedMessage>;
 		recentJoins: Map<string, number[]>;
+		personalityCache: BoundedMap<string, string>;
 	}
 }

--- a/src/lib/personality/buildProfile.ts
+++ b/src/lib/personality/buildProfile.ts
@@ -1,0 +1,61 @@
+import { container } from "@sapphire/framework";
+import { callOllama } from "../ollama.js";
+import { deleteAbsorbedMessages, getPersonalityProfile, getUnabsorbedMessages, upsertPersonalityProfile } from "../../db/queries/personality.js";
+import type { BhayanakClient } from "../BhayanakClient.js";
+
+const OLLAMA_TIMEOUT_MS = 120_000;
+
+const SYSTEM_PROMPT = [
+	"You are a personality analyst building a detailed psychological and social profile of a person based solely on their Discord messages.",
+	"Analyze and describe the following dimensions in depth:",
+	"1. Communication style — how they write, sentence structure, vocabulary, formality level, use of emojis/slang",
+	"2. Humor — type of humor they use (dry, absurdist, self-deprecating, dark, wholesome, etc.), frequency, how they land jokes",
+	"3. Topics and interests — recurring subjects, hobbies, passions, things they bring up unprompted",
+	"4. Social dynamics — how they interact with others, are they dominant/passive, do they support others, how they handle conflict or disagreement",
+	"5. Emotional tone — general mood, optimism/pessimism, what makes them excited or frustrated",
+	"6. Notable quirks and phrases — recurring expressions, catchphrases, verbal tics, unusual patterns",
+	"7. Patterns over time — any shifts in behavior, energy, or topics you can observe",
+	"Write in flowing prose, not bullet points. Be specific and detailed — the more nuanced the better.",
+	"Do not be generic. Ground every observation in evidence from the messages.",
+].join(" ");
+
+export async function buildPersonalityProfile(userId: string, guildId: string): Promise<void> {
+	const messages = await getUnabsorbedMessages(userId, guildId);
+	if (messages.length === 0) return;
+
+	const existingProfile = await getPersonalityProfile(userId, guildId);
+
+	const messageBlock = messages.map((m) => m.content).join("\n");
+
+	const userPrompt = existingProfile
+		? [
+				"Current personality profile:",
+				existingProfile,
+				"",
+				"New messages from this person since the last profile update:",
+				messageBlock,
+				"",
+				"Refine and expand the personality profile by incorporating insights from the new messages. Keep all previous observations that still hold true and deepen them. Add new observations where the new messages reveal something not previously captured.",
+			].join("\n")
+		: [
+				"Messages from this person:",
+				messageBlock,
+				"",
+				"Build a detailed personality profile based on these messages.",
+			].join("\n");
+
+	const result = await callOllama(SYSTEM_PROMPT, userPrompt, OLLAMA_TIMEOUT_MS);
+	if (!result) {
+		container.logger.warn(`[personality] Ollama returned null for userId=${userId} guildId=${guildId}, skipping profile update`);
+		return;
+	}
+
+	await upsertPersonalityProfile(userId, guildId, result);
+	await deleteAbsorbedMessages(messages.map((m) => m.id));
+
+	// Invalidate in-memory cache so the next response picks up the fresh profile
+	const client = container.client as BhayanakClient;
+	client.personalityCache.delete(`${userId}:${guildId}`);
+
+	container.logger.debug(`[personality] Profile updated for userId=${userId} guildId=${guildId} (${messages.length} messages absorbed)`);
+}

--- a/src/lib/personality/getPersonalityContext.ts
+++ b/src/lib/personality/getPersonalityContext.ts
@@ -1,0 +1,21 @@
+import { getPersonalityProfile } from "../../db/queries/personality.js";
+import type { BhayanakClient } from "../BhayanakClient.js";
+
+/**
+ * Returns a formatted personality context string to prepend to LLM system prompts.
+ * Returns an empty string if no profile exists yet (graceful degradation).
+ */
+export async function getPersonalityContext(client: BhayanakClient, userId: string, guildId: string): Promise<string> {
+	const cacheKey = `${userId}:${guildId}`;
+
+	const cached = client.personalityCache.get(cacheKey);
+	if (cached !== undefined) return cached;
+
+	const profile = await getPersonalityProfile(userId, guildId);
+	const result = profile
+		? `[Personality profile for the user you are responding to:\n${profile}]\n\n`
+		: "";
+
+	client.personalityCache.set(cacheKey, result);
+	return result;
+}

--- a/src/lib/rpg/helpers/flavorText.ts
+++ b/src/lib/rpg/helpers/flavorText.ts
@@ -358,6 +358,7 @@ export async function generateFlavorText(context: {
 	petType?: string;
 	activeItem?: string;
 	jobStreak?: number;
+	personalityContext?: string;
 }): Promise<string> {
 	const outcomeWord = context.success ? "succeeded" : "failed";
 	const payClause = context.pay !== undefined ? ` earning ${context.pay} coins` : "";
@@ -371,10 +372,7 @@ export async function generateFlavorText(context: {
 			: "";
 	const prompt = `${context.playerName}${levelClause} just ${outcomeWord} at ${context.action}${payClause}${detailsClause}.${petClause}${itemClause}${streakClause} Narrate in 1 to 4 witty sentences.`;
 
-	const text = await callOllama(
-		"You are a witty RPG narrator. Write 1 to 4 sentences. No quotation marks.",
-		prompt,
-		2000,
-	);
+	const narratorSystem = (context.personalityContext ?? "") + "You are a witty RPG narrator. Write 1 to 4 sentences. No quotation marks.";
+	const text = await callOllama(narratorSystem, prompt, 2000);
 	return text ?? fallback(context.success, context.action);
 }

--- a/src/listeners/messages/mentionResponder.ts
+++ b/src/listeners/messages/mentionResponder.ts
@@ -1,6 +1,8 @@
 import { Listener } from "@sapphire/framework";
 import { Events, type Message } from "discord.js";
 import { callOllama } from "../../lib/ollama.js";
+import { getPersonalityContext } from "../../lib/personality/getPersonalityContext.js";
+import type { BhayanakClient } from "../../lib/BhayanakClient.js";
 
 const HISTORY_LIMIT = 20;
 const OLLAMA_TIMEOUT_MS = 60_000;
@@ -51,7 +53,11 @@ export class MentionResponderListener extends Listener<typeof Events.MessageCrea
 
 		await channel.sendTyping().catch(() => null);
 
-		const response = await callOllama(SYSTEM_PROMPT, prompt, OLLAMA_TIMEOUT_MS);
+		const client = message.client as BhayanakClient;
+		const personalityCtx = await getPersonalityContext(client, message.author.id, message.guildId!);
+		const systemWithPersonality = personalityCtx + SYSTEM_PROMPT;
+
+		const response = await callOllama(systemWithPersonality, prompt, OLLAMA_TIMEOUT_MS);
 		if (!response) return;
 
 		await message.reply(response).catch(() => null);

--- a/src/listeners/messages/messageCreate.ts
+++ b/src/listeners/messages/messageCreate.ts
@@ -5,11 +5,17 @@ import { addXp } from "../../db/queries/users.js";
 import { createCase } from "../../db/queries/modCases.js";
 import { getAfk, clearAfk } from "../../db/queries/afk.js";
 import { findMatchingResponse } from "../../db/queries/autoResponses.js";
+import { storeUserMessage, incrementMessageCount } from "../../db/queries/personality.js";
 import { generateAutoResponse } from "../../lib/autoresponder/llmResponse.js";
+import { buildPersonalityProfile } from "../../lib/personality/buildProfile.js";
+import { getPersonalityContext } from "../../lib/personality/getPersonalityContext.js";
 import type { BhayanakClient } from "../../lib/BhayanakClient.js";
 
 // Spam tracking: Map<guildId:userId, { count, resetAt }>
 const spamTracker = new Map<string, { count: number; resetAt: number }>();
+
+// Prevents concurrent profile rebuilds when two messages arrive simultaneously and both see count >= 100
+const profileRebuildInProgress = new Set<string>();
 
 // Auto-responder cooldown: Map<guildId:trigger, lastFiredAt>
 const autoResponderCooldown = new Map<string, number>();
@@ -26,6 +32,19 @@ export class MessageCreateListener extends Listener {
 		if (message.author.bot || !message.guild) return;
 
 		const settings = await getOrCreateSettings(message.guild.id);
+
+		// --- Personality profiling: store message + trigger rebuild when threshold hit ---
+		// Skip empty messages and command invocations
+		const trimmedContent = message.content.trim();
+		if (trimmedContent.length > 0 && !trimmedContent.startsWith("/")) {
+			await storeUserMessage(message.author.id, message.guild.id, trimmedContent);
+			const count = await incrementMessageCount(message.author.id, message.guild.id);
+			const rebuildKey = `${message.author.id}:${message.guild.id}`;
+			if (count >= 100 && !profileRebuildInProgress.has(rebuildKey)) {
+				profileRebuildInProgress.add(rebuildKey);
+				void buildPersonalityProfile(message.author.id, message.guild.id).finally(() => profileRebuildInProgress.delete(rebuildKey));
+			}
+		}
 
 		// --- AFK clear ---
 		const afk = await getAfk(message.author.id, message.guild.id);
@@ -114,7 +133,10 @@ export class MessageCreateListener extends Listener {
 			} else {
 				autoResponderCooldown.set(cooldownKey, Date.now());
 				if (match.responseType === "llm") {
-					const reply = await generateAutoResponse(match.response, message.content, message.author.username);
+					const client = this.container.client as BhayanakClient;
+					const personalityCtx = await getPersonalityContext(client, message.author.id, message.guild.id);
+					const systemWithPersonality = personalityCtx + match.response;
+					const reply = await generateAutoResponse(systemWithPersonality, message.content, message.author.username);
 					this.container.logger.debug(`[autoresponder] LLM reply=${reply ? `"${reply.slice(0, 50)}"` : "null (skipping)"}`);
 					if (reply) await message.reply(reply).catch(() => null);
 				} else {

--- a/src/scheduled-tasks/refreshPersonalityProfiles.ts
+++ b/src/scheduled-tasks/refreshPersonalityProfiles.ts
@@ -1,0 +1,25 @@
+import { ScheduledTask } from "@sapphire/plugin-scheduled-tasks";
+import { getUsersNeedingRefresh } from "../db/queries/personality.js";
+import { buildPersonalityProfile } from "../lib/personality/buildProfile.js";
+
+export class RefreshPersonalityProfilesTask extends ScheduledTask {
+	public constructor(context: ScheduledTask.LoaderContext, options: ScheduledTask.Options) {
+		super(context, { ...options, name: "refreshPersonalityProfiles" });
+	}
+
+	public async run(): Promise<void> {
+		const users = await getUsersNeedingRefresh();
+		if (users.length === 0) return;
+
+		this.container.logger.info(`[personality] Refreshing profiles for ${users.length} user(s)`);
+
+		// Run sequentially — Ollama is a local instance, parallel calls would overwhelm it
+		for (const { userId, guildId } of users) {
+			try {
+				await buildPersonalityProfile(userId, guildId);
+			} catch (err) {
+				this.container.logger.error(`[personality] Failed to build profile for userId=${userId} guildId=${guildId}:`, err);
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Stores every non-bot, non-command Discord message per user in a new `user_messages` table
- Ollama builds and continuously refines a cumulative personality profile per user (guided across 7 dimensions: communication style, humor, interests, social dynamics, emotional tone, quirks, patterns)
- Profile is injected into the system prompt of all LLM responses (mention responder, auto-responses, RPG flavor text via `/work` and `/crime`)
- Hybrid refresh: fires when a user hits 100 new messages OR every 6 hours (whichever comes first); raw messages are deleted after absorption

## New features

- `/personality` command (admin-only, ephemeral) — view any user's current profile
- Concurrency guard prevents duplicate profile builds at the 100-message threshold
- Graceful degradation — if no profile exists yet, all existing LLM behavior is unchanged

## Migration

Run `pnpm db:migrate` to create the `user_messages` and `user_personality_profiles` tables (includes index on `(user_id, guild_id)` for fast lookups).

## Test plan

- [ ] Run `pnpm db:migrate` and confirm both new tables exist in DB
- [ ] Send messages in a test channel and confirm rows appear in `user_messages`
- [ ] Trigger a manual profile build and confirm profile is saved + messages deleted
- [ ] Confirm scheduled task fires at startup and processes stale users
- [ ] Send 100 messages rapidly and confirm rebuild fires (check logs)
- [ ] @mention the bot for a user with a profile and confirm personality context is present
- [ ] Run `/personality` as admin for self and another user
- [ ] Confirm new users with no profile still get normal LLM responses

🤖 Generated with [Claude Code](https://claude.com/claude-code)