### PR TITLE
fix: fall back to followUp when pfp-edit upload fails

### DIFF
--- a/src/commands/fun/pfp-edit.ts
+++ b/src/commands/fun/pfp-edit.ts
@@ -164,13 +164,18 @@ export class PfpEditCommand extends Command {
 			await interaction.editReply({ embeds: [embed], files: [attachment] });
 		} catch {
 			// HTTP/2 connection to Discord may have gone stale during long image generation.
-			return interaction.editReply({
-				embeds: [
-					new EmbedBuilder()
-						.setColor(0xed4245)
-						.setDescription("Image was generated but failed to upload to Discord. Please try again."),
-				],
-			});
+			// Fall back to followUp which opens a fresh connection.
+			try {
+				await interaction.followUp({ embeds: [embed], files: [attachment] });
+			} catch {
+				return interaction.editReply({
+					embeds: [
+						new EmbedBuilder()
+							.setColor(0xed4245)
+							.setDescription("Image was generated but failed to upload to Discord. Please try again."),
+					],
+				});
+			}
 		}
 
 		await setCooldown(interaction.user.id, "pfp-edit", USER_COOLDOWN_MS);


### PR DESCRIPTION
## Summary

- When `editReply` with the generated image attachment fails (stale HTTP/2 connection after long CPU generation), attempt `interaction.followUp` as a fallback before showing the error message
- `followUp` opens a fresh connection and should succeed where `editReply` failed
- Only shows "failed to upload" error if both attempts fail

## Test plan

- [ ] Run `/pfp-edit` with an effect and verify image posts successfully
- [ ] Verify cooldown is still applied after a successful `followUp` fallback

🤖 Generated with [Claude Code](https://claude.ai/code)