### PR TITLE
feat: trigger personality build from /personality command

### DIFF
--- a/src/commands/utility/personality.ts
+++ b/src/commands/utility/personality.ts
@@ -1,6 +1,7 @@
 import { Command } from "@sapphire/framework";
 import { EmbedBuilder } from "discord.js";
-import { getPersonalityProfile } from "../../db/queries/personality.js";
+import { getPersonalityProfile, getUnabsorbedMessages } from "../../db/queries/personality.js";
+import { buildPersonalityProfile } from "../../lib/personality/buildProfile.js";
 
 const FIELD_LIMIT = 1024;
 
@@ -27,12 +28,40 @@ export class PersonalityCommand extends Command {
 		const profile = await getPersonalityProfile(target.id, guildId);
 
 		if (!profile) {
+			const messages = await getUnabsorbedMessages(target.id, guildId);
+
+			if (messages.length > 0) {
+				// Messages collected but profile not built yet — trigger build now
+				void buildPersonalityProfile(target.id, guildId).catch((err) =>
+					this.container.logger.error(
+						`[personality] Manual build failed for userId=${target.id} guildId=${guildId}:`,
+						err,
+					),
+				);
+
+				return interaction.editReply({
+					embeds: [
+						new EmbedBuilder()
+							.setColor(0x57f287)
+							.setTitle(`Personality Profile — ${target.displayName}`)
+							.setDescription(
+								`No profile exists yet, but **${messages.length}** message(s) have been collected.\n\n` +
+									`Profile building has been triggered — check back in a minute or two.`,
+							),
+					],
+				});
+			}
+
+			// No messages at all — nothing to build from
 			return interaction.editReply({
 				embeds: [
 					new EmbedBuilder()
 						.setColor(0xfee75c)
 						.setTitle(`Personality Profile — ${target.displayName}`)
-						.setDescription("No personality profile exists for this user yet. The bot needs more messages to build one."),
+						.setDescription(
+							"No personality profile exists yet, and no messages have been collected.\n\n" +
+								"The profile will build automatically once enough plain-text messages have been sent.",
+						),
 				],
 			});
 		}


### PR DESCRIPTION
## Summary

- When `/personality @user` is run and no profile exists but messages have been collected, the command now fires `buildPersonalityProfile` in the background and replies with a green embed showing how many messages were collected and a prompt to check back shortly
- When no messages have been collected at all, the yellow embed is shown with clearer wording ("no messages collected yet" rather than the generic previous message)
- When a profile already exists, behavior is unchanged

## Test plan

- [ ] Run `/personality @user` for a user with collected messages but no profile → should see green "build triggered" embed with message count
- [ ] Wait ~1-2 minutes, run again → should now show the full profile
- [ ] Run `/personality @user` for a user with zero messages → should see yellow "no messages yet" embed
- [ ] Run `/personality @user` for a user with an existing profile → unchanged behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)