### PR TITLE
Fix migration container and switch to Docker networking

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,16 +14,17 @@ COPY . .
 # migration: minimal image to run database migrations (no ffmpeg/python/build deps)
 FROM node:22-alpine AS migration
 
-RUN npm install -g pnpm drizzle-kit
-
-ENV NODE_PATH=/usr/local/lib/node_modules
+RUN npm install -g pnpm
 
 WORKDIR /app
+
+COPY package.json pnpm-lock.yaml .npmrc ./
+RUN pnpm install --frozen-lockfile --ignore-scripts && pnpm rebuild esbuild
 
 COPY drizzle.config.ts ./
 COPY drizzle/ ./drizzle/
 
-CMD ["drizzle-kit", "migrate"]
+CMD ["pnpm", "exec", "drizzle-kit", "migrate"]
 
 # build: compiles TypeScript and web frontend on top of base
 FROM base AS build

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,7 @@ services:
       postgres:
         condition: service_healthy
     environment:
-      DATABASE_URL: postgresql://postgres:${POSTGRES_PASSWORD:-postgres}@postgres:2222/bhayanakbot
+      DATABASE_URL: ${DATABASE_URL:-postgresql://postgres:postgres@postgres:5432/bhayanakbot}
       NODE_ENV: production
     networks:
       - botnet
@@ -106,7 +106,7 @@ services:
     ports:
       - "${WEB_PORT:-3000}:${WEB_PORT:-3000}"
     environment:
-      DATABASE_URL: postgresql://postgres:${POSTGRES_PASSWORD:-postgres}@postgres:2222/bhayanakbot
+      DATABASE_URL: ${DATABASE_URL:-postgresql://postgres:postgres@postgres:5432/bhayanakbot}
       VALKEY_URL: ${VALKEY_URL:-redis://valkey:6379}
       OLLAMA_URL: ${OLLAMA_URL:-http://ollama:11434}
       OLLAMA_MODEL: ${OLLAMA_MODEL}


### PR DESCRIPTION
## Summary

- **Migration container**: replaced global `drizzle-kit` install with a local `pnpm install`; added `pnpm rebuild esbuild` so drizzle-kit's tsx loader has its native binary (fixes _"Please install latest version of drizzle-orm"_ error)
- **CMD fix**: switched from `["drizzle-kit", "migrate"]` (not on PATH in exec form) to `["pnpm", "exec", "drizzle-kit", "migrate"]`
- **Networking**: fixed `DATABASE_URL` in `migrate` and `bot` services — was pointing to `postgres:2222`, now uses `postgres:5432` via `${DATABASE_URL:-...}` substitution; all service URL defaults consistently use Docker service hostnames

## Test plan

- [x] Built migration image locally — `pnpm rebuild esbuild` ran successfully for all esbuild versions
- [x] Ran `docker compose up migrate` — migrations applied successfully (exit code 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)