### PR TITLE
feat: add live Palworld player tracker as Discord channels

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,4 +34,10 @@ GUESS_WHO_BACKFILL_LIMIT=1000
 # Optional privileged Discord user ID. Leave blank to disable owner bypasses.
 BOT_OWNER_ID=
 
+# Palworld live player tracker. The tracker runs as soon as the admin key is set.
+# PALWORLD_API_URL defaults to http://127.0.0.1:8212 — set it explicitly when the bot
+# runs in Docker, where localhost is the container rather than the Palworld host.
+PALWORLD_API_URL=
+PALWORLD_ADMIN_KEY=
+
 YOUTUBE_COOKIE=

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,6 +118,8 @@ Keep `.env.example`, `README.md`, Docker Compose, and this table in sync when en
 | `GUESS_WHO_CHANNEL_ID` | `199168135935295488` | Channel whose messages are archived and where `/guess_who` can run |
 | `GUESS_WHO_BACKFILL_LIMIT` | `1000` | Maximum Discord messages scanned during startup backfill for Guess Who archive |
 | `BOT_OWNER_ID` | unset | Optional privileged Discord user ID; blank/unset disables owner bypasses |
+| `PALWORLD_API_URL` | `http://127.0.0.1:8212` | Palworld REST API base URL; the default assumes the server shares a host with the bot, which is false under Docker |
+| `PALWORLD_ADMIN_KEY` | unset | Palworld `AdminPassword`, sent as HTTP Basic auth with username `admin`; setting it enables the live player tracker |
 
 ## Message Archive And Personality
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -50,6 +50,28 @@ A `/guess_who` round can stay active for up to ten minutes in its channel. If no
 
 A Discord jump link to the original message represented by an archived channel message. Game reveals use this link so players can inspect the source message after the author is revealed.
 
+## Palworld Tracker Category
+
+The Discord category whose name carries the live online count (e.g. "Bhayanak Palworld — 4 online") and which holds the live Palworld player roster. The category's channel list *is* the roster: one text channel exists for exactly as long as its player is connected to the Palworld server. The category is owned by the bot — its contents are derived state, rewritten on every tracker sweep, not a place for durable conversation.
+
+The category is identified by name, not by a stored ID, and is created on demand when missing. Its *existence* encodes reachability: the bot deletes the entire category when the Palworld server is unreachable and recreates it on the next successful sweep. So an absent category means "the bot cannot see the server", while a present category with no player channels means "the server is up and nobody is online" — the two states are never confused.
+
+## Tracker Sweep
+
+One pass of the Palworld tracker: fetch the connected players, compare them against the Palworld Player Channels currently in the Palworld Tracker Category, and create or delete channels so the two agree. A sweep is the only thing that mutates the category. Only a successful fetch drives create/delete; a successful fetch reporting nobody online is meaningful and clears the player channels without touching the category itself. Two consecutive failed sweeps mean the server is Unreachable.
+
+## Unreachable
+
+The state entered after two consecutive failed sweeps, where "failed" means the Palworld API did not answer with a usable response. Reaching it deletes the Palworld Tracker Category outright; the next successful sweep recreates it. One isolated failure is not Unreachable — Palworld servers stall briefly during world saves, and a single stall must not tear down the roster.
+
+## Palworld Player Channel
+
+A Discord text channel inside the Palworld Tracker Category representing one player currently connected to the Palworld server. Its *name* pairs the player's in-game character name with their platform account name and their current level — "character - account - level" — because the two names differ and members recognise players by both. When the two names are the same, only one is shown. The name is for humans only and is lossy: Discord lowercases it, dashes spaces, and strips characters, so it is never used to identify a player. Its *topic* carries the player's Palworld `userId` (platform account, stable across sessions and character rerolls), which is the identity key the tracker sweeps on. It is created when the player is first observed connected and deleted when the player is first observed disconnected.
+
+A player's character name can be absent while they are still connecting, so the name falls back to whichever part is present, and to a `userId`-derived label when neither is — a channel with no name cannot exist.
+
+The level in the name is live, not a login snapshot: a sweep that observes a player at a different level renames their channel to match. A channel is renamed only when what it says has actually stopped being true, so a player who does not level up is never renamed at all. Because the channel is deleted on disconnect, any messages posted in it would be lost; the channel is therefore readable by everyone but writable by no one. It is a presence indicator, not a conversation, and its permissions say so rather than relying on members to infer it.
+
 ## Public Bot Stats Snapshot
 
 A database-stored set of public marketing-site metrics written by the running bot after startup. The web app reads the latest snapshot from the database. If the bot is offline or fails to start, the web app may continue showing the most recent stored snapshot as stale data instead of inventing fallback numbers.

--- a/README.md
+++ b/README.md
@@ -112,6 +112,8 @@ TARGET_TEXT_CHANNEL_ID=199168135935295488
 GUESS_WHO_CHANNEL_ID=199168135935295488
 GUESS_WHO_BACKFILL_LIMIT=1000
 BOT_OWNER_ID=                         # optional privileged Discord user ID; blank disables owner bypasses
+PALWORLD_API_URL=                     # optional; defaults to http://127.0.0.1:8212. Required under Docker
+PALWORLD_ADMIN_KEY=                   # optional; Palworld AdminPassword — tracker runs once this is set
 YOUTUBE_COOKIE=
 ```
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -94,6 +94,9 @@ services:
       DISCORD_TOKEN: ${DISCORD_TOKEN}
       DISCORD_CLIENT_ID: ${DISCORD_CLIENT_ID}
       BOT_OWNER_ID: ${BOT_OWNER_ID:-}
+      TARGET_GUILD_ID: ${TARGET_GUILD_ID:-}
+      PALWORLD_API_URL: ${PALWORLD_API_URL:-}
+      PALWORLD_ADMIN_KEY: ${PALWORLD_ADMIN_KEY:-}
       NODE_ENV: ${NODE_ENV:-production}
     networks:
       - botnet

--- a/docs/adr/0003-delete-category-when-palworld-unreachable.md
+++ b/docs/adr/0003-delete-category-when-palworld-unreachable.md
@@ -1,0 +1,13 @@
+# Delete the tracker category when the Palworld server is unreachable
+
+The Palworld tracker renders the live player roster as Discord channels inside a category, where an empty category legitimately means "the server is up and nobody is online". That leaves no way to also express "the bot cannot see the server" — both states look like a category with no player channels. We resolved it by making the category's *existence* the reachability signal: after two consecutive failed sweeps the bot deletes the entire category, and the next successful sweep recreates it.
+
+## Considered Options
+
+Keeping the category and renaming it to something like "Bhayanak Palworld — offline" was the obvious alternative. It preserves the category's position in the sidebar and avoids churn, but channel name changes are rate-limited to 2 per 10 minutes and the category already spends that budget on its online count, so the offline marker could not be relied on to appear promptly. Leaving stale player channels in place was rejected outright — a roster that keeps showing players who may have logged out hours ago is worse than no roster.
+
+## Consequences
+
+The category is disposable, so nothing durable may live in it: no pinned messages, no member-written content, no manually added channels. Anything a human puts there is destroyed the next time the Palworld API has a bad two minutes. This is why player channels are read-only, and why the category is looked up by name and created on demand rather than tracked by a stored ID.
+
+A single failed sweep deliberately does not trigger deletion. Palworld servers stall while saving the world, and one stall must not tear down the roster.

--- a/src/index.ts
+++ b/src/index.ts
@@ -164,6 +164,7 @@ async function main() {
 			"reloadOnRestart",
 			"generateDailyQuests",
 			"refreshPersonalityProfiles",
+			"syncPalworldTracker",
 		];
 		for (const taskName of startupTasks) {
 			void runTask(taskName);
@@ -207,6 +208,26 @@ async function main() {
 				}
 			},
 			6 * 60 * 60 * 1000,
+		);
+
+		// Sweep the Palworld roster every 10 minutes
+		let palworldTaskRunning = false;
+		setInterval(
+			async () => {
+				if (palworldTaskRunning) return;
+				palworldTaskRunning = true;
+				try {
+					await client.stores
+						.get("scheduled-tasks")
+						.get("syncPalworldTracker")
+						?.run(null as never);
+				} catch (err) {
+					client.logger.error("[ScheduledTask:syncPalworldTracker] Error:", err);
+				} finally {
+					palworldTaskRunning = false;
+				}
+			},
+			10 * 60 * 1000,
 		);
 
 		// Check once per hour — task is idempotent, skips if quests already exist for today

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -16,6 +16,8 @@ const envSchema = z.object({
 	GUESS_WHO_CHANNEL_ID: optionalSnowflake,
 	BOT_OWNER_ID: optionalSnowflake,
 	ZEN_ALLOW_DISCORD_CONTENT: z.enum(["true", "false"]).optional(),
+	PALWORLD_API_URL: z.string().trim().url().optional().or(z.literal("")),
+	PALWORLD_ADMIN_KEY: z.string().trim().optional(),
 	OLLAMA_MAX_QUEUE_LENGTH: z.coerce.number().int().positive().optional(),
 	OLLAMA_MAX_LOW_PRIORITY_QUEUE_LENGTH: z.coerce.number().int().positive().optional(),
 	OLLAMA_QUEUE_WAIT_TIMEOUT_MS: z.coerce.number().int().positive().optional(),

--- a/src/lib/palworld.ts
+++ b/src/lib/palworld.ts
@@ -1,0 +1,52 @@
+import { z } from "zod";
+
+const REQUEST_TIMEOUT_MS = 10_000;
+
+// The bot and the Palworld server share a host, so a bare install needs no URL.
+// Note this does NOT hold inside Docker, where localhost is the container itself —
+// deployments on the botnet bridge network must set PALWORLD_API_URL explicitly.
+const DEFAULT_API_URL = "http://127.0.0.1:8212";
+
+// Field names vary slightly across Palworld server builds, so only the fields the
+// tracker actually depends on are required. Unknown/extra fields are ignored.
+const playerSchema = z.object({
+	name: z.string().default(""),
+	accountName: z.string().default(""),
+	userId: z.string().trim().min(1),
+	level: z.coerce.number().int().nonnegative().default(0),
+});
+
+export type PalworldPlayer = z.infer<typeof playerSchema>;
+
+/** Only the admin key is required — the API URL falls back to the local server. */
+export function isPalworldConfigured(env: NodeJS.ProcessEnv = process.env): boolean {
+	return Boolean(env.PALWORLD_ADMIN_KEY?.trim());
+}
+
+/**
+ * Fetches the players currently connected to the Palworld server.
+ * Throws on any unusable response — callers treat a throw as a failed sweep.
+ */
+export async function fetchPalworldPlayers(env: NodeJS.ProcessEnv = process.env): Promise<PalworldPlayer[]> {
+	const baseUrl = env.PALWORLD_API_URL?.trim() || DEFAULT_API_URL;
+	const adminKey = env.PALWORLD_ADMIN_KEY?.trim();
+	if (!adminKey) throw new Error("PALWORLD_ADMIN_KEY is not set");
+
+	const auth = Buffer.from(`admin:${adminKey}`).toString("base64");
+	const res = await fetch(new URL("/v1/api/players", baseUrl), {
+		headers: { Authorization: `Basic ${auth}`, Accept: "application/json" },
+		signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+	});
+
+	if (!res.ok) throw new Error(`Palworld API responded ${res.status}`);
+
+	const body = z.object({ players: z.array(z.unknown()) }).safeParse(await res.json());
+	if (!body.success) throw new Error("Palworld API returned an unexpected payload");
+
+	// Drop individual malformed players rather than failing the whole sweep — one bad
+	// record must not look like an unreachable server and tear down the category.
+	return body.data.players.flatMap((entry) => {
+		const parsed = playerSchema.safeParse(entry);
+		return parsed.success ? [parsed.data] : [];
+	});
+}

--- a/src/scheduled-tasks/syncPalworldTracker.ts
+++ b/src/scheduled-tasks/syncPalworldTracker.ts
@@ -1,0 +1,184 @@
+import { ScheduledTask } from "@sapphire/plugin-scheduled-tasks";
+import { type CategoryChannel, ChannelType, type Guild, type GuildBasedChannel, PermissionFlagsBits } from "discord.js";
+import { fetchPalworldPlayers, isPalworldConfigured, type PalworldPlayer } from "../lib/palworld.js";
+
+const CATEGORY_PREFIX = "Bhayanak Palworld";
+const MAX_CHANNEL_NAME_LENGTH = 100;
+const FAILURES_BEFORE_UNREACHABLE = 2;
+
+// A single failed sweep is not enough to tear down the roster — Palworld servers stall
+// while saving the world. See docs/adr/0003-delete-category-when-palworld-unreachable.md
+let consecutiveFailures = 0;
+
+/** `Character - Account - Lv 80`, collapsing to one name when both spellings match. */
+export function playerChannelName(player: PalworldPlayer): string {
+	const character = player.name.trim();
+	const account = player.accountName.trim();
+	const parts = [character, account].filter(Boolean);
+	if (parts.length === 2 && character.toLowerCase() === account.toLowerCase()) parts.pop();
+	// A channel with no name cannot exist, so fall back to something derived from the identity key
+	const label = parts.join(" - ") || `pal-${player.userId.slice(-6)}`;
+	const suffix = ` - Lv ${player.level}`;
+	return `${label.slice(0, MAX_CHANNEL_NAME_LENGTH - suffix.length)}${suffix}`;
+}
+
+function categoryName(onlineCount: number): string {
+	return `${CATEGORY_PREFIX} — ${onlineCount} online`;
+}
+
+/**
+ * Reads the level back out of a live channel name. Discord lowercases names and turns
+ * spaces into dashes, so the name we sent is not the name we get back — but the digits
+ * survive intact. Comparing the level this way avoids re-sending a rename every sweep
+ * just because our idea of the sanitised name differs from Discord's.
+ */
+export function levelFromChannelName(name: string): number | null {
+	const match = name.match(/lv-(\d+)$/);
+	return match ? Number(match[1]) : null;
+}
+
+function findCategory(guild: Guild): CategoryChannel | undefined {
+	return guild.channels.cache.find(
+		(channel): channel is CategoryChannel =>
+			channel.type === ChannelType.GuildCategory && channel.name.startsWith(CATEGORY_PREFIX),
+	);
+}
+
+export class SyncPalworldTrackerTask extends ScheduledTask {
+	public constructor(context: ScheduledTask.LoaderContext, options: ScheduledTask.Options) {
+		super(context, { ...options, name: "syncPalworldTracker" });
+	}
+
+	public async run(): Promise<void> {
+		if (!isPalworldConfigured()) return;
+
+		const guildId = process.env.TARGET_GUILD_ID?.trim();
+		if (!guildId) {
+			this.container.logger.warn("[palworld-tracker] TARGET_GUILD_ID is not set — skipping");
+			return;
+		}
+
+		const guild = this.container.client.guilds.cache.get(guildId);
+		if (!guild) {
+			this.container.logger.warn(`[palworld-tracker] Guild ${guildId} not in cache — skipping`);
+			return;
+		}
+
+		const startedAt = Date.now();
+		this.container.logger.debug("[palworld-tracker] sweep start");
+
+		let players: PalworldPlayer[];
+		try {
+			players = await fetchPalworldPlayers();
+		} catch (err) {
+			consecutiveFailures++;
+			this.container.logger.warn(`[palworld-tracker] fetch failed (${consecutiveFailures} in a row):`, err);
+			if (consecutiveFailures >= FAILURES_BEFORE_UNREACHABLE) await this.removeCategory(guild);
+			return;
+		}
+
+		consecutiveFailures = 0;
+		await this.syncCategory(guild, players);
+		this.container.logger.debug(
+			`[palworld-tracker] sweep complete online=${players.length} durationMs=${Date.now() - startedAt}`,
+		);
+	}
+
+	/** The server is unreachable: the category's absence is how that state is expressed. */
+	private async removeCategory(guild: Guild): Promise<void> {
+		const category = findCategory(guild);
+		if (!category) return;
+
+		this.container.logger.info("[palworld-tracker] Server unreachable — removing tracker category");
+		for (const child of category.children.cache.values()) {
+			await this.deleteChannel(child, "Palworld server unreachable");
+		}
+		try {
+			await category.delete("Palworld server unreachable");
+		} catch (err) {
+			this.container.logger.error("[palworld-tracker] Failed to delete category:", err);
+		}
+	}
+
+	private async syncCategory(guild: Guild, players: PalworldPlayer[]): Promise<void> {
+		let category = findCategory(guild);
+		if (!category) {
+			category = await guild.channels.create({
+				name: categoryName(players.length),
+				type: ChannelType.GuildCategory,
+				// Player channels are deleted when their player logs off, so anything written in
+				// them would be lost. Read-only makes that plain instead of relying on members to infer it.
+				permissionOverwrites: [{ id: guild.roles.everyone.id, deny: [PermissionFlagsBits.SendMessages] }],
+				reason: "Palworld tracker",
+			});
+			this.container.logger.info("[palworld-tracker] Created tracker category");
+		}
+
+		// The topic holds the player's Palworld userId — the only reliable identity key,
+		// since display names collide and Discord mangles channel names.
+		const byUserId = new Map<string, GuildBasedChannel>();
+		const strays: GuildBasedChannel[] = [];
+		for (const child of category.children.cache.values()) {
+			const userId = child.type === ChannelType.GuildText ? child.topic?.trim() : undefined;
+			if (userId && !byUserId.has(userId)) byUserId.set(userId, child);
+			else strays.push(child);
+		}
+
+		const online = new Set(players.map((player) => player.userId));
+		let created = 0;
+		let deleted = 0;
+		let renamed = 0;
+
+		for (const [userId, channel] of byUserId) {
+			if (online.has(userId)) continue;
+			if (await this.deleteChannel(channel, "Player left the Palworld server")) deleted++;
+		}
+		// The bot owns this category outright, so anything it did not create does not belong here
+		for (const channel of strays) {
+			if (await this.deleteChannel(channel, "Not a Palworld player channel")) deleted++;
+		}
+
+		for (const player of players) {
+			const name = playerChannelName(player);
+			const channel = byUserId.get(player.userId);
+			try {
+				if (!channel) {
+					await guild.channels.create({
+						name,
+						type: ChannelType.GuildText,
+						parent: category.id,
+						topic: player.userId,
+						reason: "Player joined the Palworld server",
+					});
+					created++;
+				} else if (channel.type === ChannelType.GuildText && levelFromChannelName(channel.name) !== player.level) {
+					await channel.setName(name, "Palworld level changed");
+					renamed++;
+				}
+			} catch (err) {
+				this.container.logger.error(`[palworld-tracker] Failed to sync channel for ${player.userId}:`, err);
+			}
+		}
+
+		const desiredCategoryName = categoryName(players.length);
+		if (category.name !== desiredCategoryName) {
+			try {
+				await category.setName(desiredCategoryName, "Palworld online count changed");
+			} catch (err) {
+				this.container.logger.error("[palworld-tracker] Failed to rename category:", err);
+			}
+		}
+
+		this.container.logger.debug(`[palworld-tracker] channels created=${created} deleted=${deleted} renamed=${renamed}`);
+	}
+
+	private async deleteChannel(channel: GuildBasedChannel, reason: string): Promise<boolean> {
+		try {
+			await channel.delete(reason);
+			return true;
+		} catch (err) {
+			this.container.logger.error(`[palworld-tracker] Failed to delete channel ${channel.id}:`, err);
+			return false;
+		}
+	}
+}

--- a/tests/unit/scheduled-tasks/syncPalworldTracker.test.ts
+++ b/tests/unit/scheduled-tasks/syncPalworldTracker.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { isPalworldConfigured, type PalworldPlayer } from "../../../src/lib/palworld.js";
+import { levelFromChannelName, playerChannelName } from "../../../src/scheduled-tasks/syncPalworldTracker.js";
+
+function player(overrides: Partial<PalworldPlayer> = {}): PalworldPlayer {
+	return { name: "Z1N1", accountName: "Athena", userId: "steam_76561198271516743", level: 80, ...overrides };
+}
+
+/** Approximates what Discord does to a text channel name it is given. */
+function discordSanitize(name: string): string {
+	return name.toLowerCase().replace(/\s+/g, "-");
+}
+
+describe("isPalworldConfigured", () => {
+	it("needs only the admin key, since the URL falls back to the local server", () => {
+		expect(isPalworldConfigured({ PALWORLD_ADMIN_KEY: "secret" })).toBe(true);
+		expect(isPalworldConfigured({ PALWORLD_API_URL: "http://10.1.1.160:8212" })).toBe(false);
+		expect(isPalworldConfigured({})).toBe(false);
+	});
+});
+
+describe("playerChannelName", () => {
+	it("pairs the character and account names", () => {
+		expect(playerChannelName(player())).toBe("Z1N1 - Athena - Lv 80");
+	});
+
+	it("collapses the pair when both names are the same person", () => {
+		expect(playerChannelName(player({ name: "Ash Wednesday", accountName: "Ash Wednesday", level: 30 }))).toBe(
+			"Ash Wednesday - Lv 30",
+		);
+	});
+
+	it("falls back to the account name while the character is still connecting", () => {
+		expect(playerChannelName(player({ name: "" }))).toBe("Athena - Lv 80");
+	});
+
+	it("falls back to the identity key when neither name is present", () => {
+		expect(playerChannelName(player({ name: "", accountName: "" }))).toBe("pal-516743 - Lv 80");
+	});
+
+	it("stays within Discord's 100 character limit without losing the level", () => {
+		const name = playerChannelName(player({ name: "x".repeat(200), accountName: "" }));
+		expect(name.length).toBeLessThanOrEqual(100);
+		expect(name.endsWith(" - Lv 80")).toBe(true);
+	});
+});
+
+describe("levelFromChannelName", () => {
+	// If this round trip breaks, every sweep sees a level mismatch and renames every
+	// channel, burning the 2-per-10-minutes rename budget for no reason.
+	it("recovers the level from the name Discord actually stores", () => {
+		for (const p of [player(), player({ name: "", accountName: "" }), player({ level: 1 })]) {
+			expect(levelFromChannelName(discordSanitize(playerChannelName(p)))).toBe(p.level);
+		}
+	});
+
+	it("returns null for a channel that carries no level", () => {
+		expect(levelFromChannelName("general")).toBeNull();
+	});
+});


### PR DESCRIPTION
Sweeps the Palworld REST API every 10 minutes and mirrors connected players into a "Bhayanak Palworld" category — one read-only text channel per player, named `Character - Account - Lv N`, with the player's `userId` in the topic as the identity key.

Two consecutive failed sweeps delete the category; the next successful sweep rebuilds it, so an empty category unambiguously means "server up, nobody online". Rationale in `docs/adr/0003-delete-category-when-palworld-unreachable.md`.

`PALWORLD_ADMIN_KEY` enables the tracker. `PALWORLD_API_URL` defaults to `http://127.0.0.1:8212` and must be set explicitly under Docker.

**Verified:** API client, channel naming, and level round-trip against the live server; 320 unit + smoke tests, typecheck, and Biome all clean.
**Not verified:** the Discord side — category creation, deletion, and the permission overwrite need the bot running against a real guild.