### PR TITLE
fix: ship full src in production image and stop emitting .d.ts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,9 @@ RUN pnpm install --frozen-lockfile
 COPY drizzle.config.ts ./
 COPY drizzle/ ./drizzle/
 COPY web/ ./web/
-COPY src/db/ ./src/db/
+# The web service builds Astro at runtime and imports src/db queries, which in
+# turn reach into src/lib, so the whole source tree has to be here.
+COPY src/ ./src/
 COPY tsconfig.json ./
 COPY --from=base /app/dist ./dist
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,8 +12,10 @@
 		"emitDecoratorMetadata": true,
 		"skipLibCheck": true,
 		"resolveJsonModule": true,
-		"declaration": true,
-		"declarationMap": true,
+		// Nothing consumes dist as a library, and .d.ts files in dist make the
+		// Sapphire piece loader log EMPTY_MODULE for every command.
+		"declaration": false,
+		"declarationMap": false,
 		"sourceMap": true,
 		"paths": {
 			"#/*": ["./src/*"]


### PR DESCRIPTION
Two boot-time failures seen in the deployed `bhayanak_bot` stack.

## `bhayanak_bot_web` crash loop

```
Could not resolve "../../lib/database.js" from "src/db/queries/publicStats.ts"
```

The web service runs `astro build` at container start. `web/src/data/publicStatsDb.ts` imports `src/db/queries/publicStats.ts`, which imports `src/lib/database.js`. The production stage only copied `src/db/`, so `/app/src/lib` did not exist in the image and the container restarted every ~14s. Now copies the whole `src/` tree.

## `EMPTY_MODULE` spam on bot boot

`tsc` emitted `.d.ts` alongside the JS in `dist`, and the Sapphire piece loader tried to load them as commands — one error per command every boot. Nothing consumes `dist` as a library, so `declaration`/`declarationMap` are off.

## Verification

- `pnpm build` → 0 `.d.ts` in `dist`
- `pnpm web:build` → completes