### PR TITLE
fix(palworld-tracker): don't read the role cache when creating the category

### DIFF
--- a/src/scheduled-tasks/syncPalworldTracker.ts
+++ b/src/scheduled-tasks/syncPalworldTracker.ts
@@ -108,7 +108,9 @@ export class SyncPalworldTrackerTask extends ScheduledTask {
 				type: ChannelType.GuildCategory,
 				// Player channels are deleted when their player logs off, so anything written in
 				// them would be lost. Read-only makes that plain instead of relying on members to infer it.
-				permissionOverwrites: [{ id: guild.roles.everyone.id, deny: [PermissionFlagsBits.SendMessages] }],
+				// The @everyone role id is always the guild id. `guild.roles.everyone` reads the
+				// role cache, which is still empty when this task runs on startup before ready.
+				permissionOverwrites: [{ id: guild.id, deny: [PermissionFlagsBits.SendMessages] }],
 				reason: "Palworld tracker",
 			});
 			this.container.logger.info("[palworld-tracker] Created tracker category");


### PR DESCRIPTION
Live log from the deployed bot:

```
[startup] Task syncPalworldTracker failed after 35ms:
  TypeError: Cannot read properties of undefined (reading 'id')
    at SyncPalworldTrackerTask.syncCategory (dist/scheduled-tasks/syncPalworldTracker.js:101:67)
```

The startup task runner fires `syncPalworldTracker` **before** the `ready` event (the failure is logged one line above `[ready] Logged in as ...`), so the guild role cache is still empty and `guild.roles.everyone` is `undefined`.

`guild.roles.everyone` is just `roles.cache.get(guild.id)` — the @everyone role id is always the guild id — so `guild.id` gives the same value with no cache dependency.

The three other `roles.everyone` call sites (`ticket.ts`, `ticketButtons.ts`, `userinfo.ts`) all run from interactions, where the guild is fully cached, so they are unaffected.

## Verification
- `pnpm build` clean
- 318 unit tests pass (integration tests need a local postgres and fail identically on `main`)
- Verified on the LXC that the bot container can now reach the Palworld API and the fetch itself succeeds