### PR TITLE
fix(palworld-tracker): fetch guild channels and roles before sweeping

### DIFF
--- a/src/scheduled-tasks/syncPalworldTracker.ts
+++ b/src/scheduled-tasks/syncPalworldTracker.ts
@@ -58,9 +58,20 @@ export class SyncPalworldTrackerTask extends ScheduledTask {
 			return;
 		}
 
-		const guild = this.container.client.guilds.cache.get(guildId);
+		const guild = await this.container.client.guilds.fetch(guildId).catch(() => null);
 		if (!guild) {
-			this.container.logger.warn(`[palworld-tracker] Guild ${guildId} not in cache — skipping`);
+			this.container.logger.warn(`[palworld-tracker] Guild ${guildId} is unavailable — skipping`);
+			return;
+		}
+
+		// index.ts runs this task once at startup, before the ready event has filled the
+		// caches. Without these fetches the sweep sees a guild with no channels — it would
+		// miss the existing category and create a duplicate — and no roles, which makes
+		// Discord reject the @everyone permission overwrite as an uncached role.
+		try {
+			await Promise.all([guild.channels.fetch(), guild.roles.fetch()]);
+		} catch (err) {
+			this.container.logger.warn("[palworld-tracker] Failed to load guild channels/roles — skipping:", err);
 			return;
 		}
 
@@ -108,9 +119,7 @@ export class SyncPalworldTrackerTask extends ScheduledTask {
 				type: ChannelType.GuildCategory,
 				// Player channels are deleted when their player logs off, so anything written in
 				// them would be lost. Read-only makes that plain instead of relying on members to infer it.
-				// The @everyone role id is always the guild id. `guild.roles.everyone` reads the
-				// role cache, which is still empty when this task runs on startup before ready.
-				permissionOverwrites: [{ id: guild.id, deny: [PermissionFlagsBits.SendMessages] }],
+				permissionOverwrites: [{ id: guild.roles.everyone.id, deny: [PermissionFlagsBits.SendMessages] }],
 				reason: "Palworld tracker",
 			});
 			this.container.logger.info("[palworld-tracker] Created tracker category");


### PR DESCRIPTION
Follow-up to #81, which treated a symptom. Live log after that deploy:

```
[startup] Task syncPalworldTracker failed after 34ms:
  DiscordjsTypeError [InvalidType]: Supplied parameter is not a cached User or Role.
```

## Root cause

`src/index.ts:141-171` fires the startup tasks immediately after `client.login()`, i.e. **before** the `ready` event has populated any cache. So inside the task:

- `guild.channels.cache` is empty → `findCategory` finds nothing → the sweep would create a **second** tracker category on every restart
- `guild.roles.cache` is empty → discord.js cannot resolve the @everyone overwrite and throws

#81 swapped `guild.roles.everyone.id` for `guild.id` to dodge the role cache, but discord.js resolves the overwrite target against the cache regardless, so it still threw — and it left the duplicate-category bug untouched.

## Fix

Fetch the guild and its channels and roles at the top of `run()`. That covers every cache the sweep reads, so the overwrite resolves and the existing category is found. Reverted to `guild.roles.everyone.id` now that it is safe.

## Verification
- `pnpm build` clean
- 318 unit tests pass