### PR TITLE
fix(palworld-tracker): rename channels when the player name changes

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -70,7 +70,7 @@ A Discord text channel inside the Palworld Tracker Category representing one pla
 
 A player's account name can be absent while they are still connecting, so the name falls back to the character name, and to a `userId`-derived label when neither is present — a channel with no name cannot exist.
 
-The level in the name is live, not a login snapshot: a sweep that observes a player at a different level renames their channel to match. A channel is renamed only when what it says has actually stopped being true, so a player who does not level up is never renamed at all. Because the channel is deleted on disconnect, any messages posted in it would be lost; the channel is therefore readable by everyone but writable by no one. It is a presence indicator, not a conversation, and its permissions say so rather than relying on members to infer it.
+The name is live, not a login snapshot: a sweep that observes a player under a different account name or at a different level renames their channel to match. A channel is renamed only when what it says has actually stopped being true, so a player whose name and level are unchanged is never renamed at all. Because Discord rewrites the name it is given, "unchanged" is judged on the letters and digits alone — a name that differs only in punctuation or spacing is left as it is, rather than being renamed on every sweep by a comparison that can never agree with itself. Because the channel is deleted on disconnect, any messages posted in it would be lost; the channel is therefore readable by everyone but writable by no one. It is a presence indicator, not a conversation, and its permissions say so rather than relying on members to infer it.
 
 ## Public Bot Stats Snapshot
 

--- a/src/scheduled-tasks/syncPalworldTracker.ts
+++ b/src/scheduled-tasks/syncPalworldTracker.ts
@@ -26,14 +26,15 @@ function categoryName(onlineCount: number): string {
 }
 
 /**
- * Reads the level back out of a live channel name. Discord lowercases names and turns
- * spaces into dashes, so the name we sent is not the name we get back — but the digits
- * survive intact. Comparing the level this way avoids re-sending a rename every sweep
- * just because our idea of the sanitised name differs from Discord's.
+ * Reduces a channel name to a form both we and Discord agree on. Discord lowercases names,
+ * turns spaces into dashes and silently drops characters it dislikes, so the name we sent
+ * is never the name we read back. Keeping only letters and digits means every separator
+ * Discord might rewrite or drop is gone from both sides, so a rename that can never
+ * converge is never re-sent on every sweep. Lossy on purpose: two names differing only in
+ * punctuation compare equal and simply keep the name they already have.
  */
-export function levelFromChannelName(name: string): number | null {
-	const match = name.match(/lv-(\d+)$/);
-	return match ? Number(match[1]) : null;
+export function channelNameSlug(name: string): string {
+	return name.toLowerCase().replace(/[^a-z0-9]/g, "");
 }
 
 function findCategory(guild: Guild): CategoryChannel | undefined {
@@ -161,8 +162,9 @@ export class SyncPalworldTrackerTask extends ScheduledTask {
 						reason: "Player joined the Palworld server",
 					});
 					created++;
-				} else if (channel.type === ChannelType.GuildText && levelFromChannelName(channel.name) !== player.level) {
-					await channel.setName(name, "Palworld level changed");
+				} else if (channel.type === ChannelType.GuildText && channelNameSlug(channel.name) !== channelNameSlug(name)) {
+					// Covers a level change and a display name that has changed under us
+					await channel.setName(name, "Palworld player name or level changed");
 					renamed++;
 				}
 			} catch (err) {

--- a/tests/unit/scheduled-tasks/syncPalworldTracker.test.ts
+++ b/tests/unit/scheduled-tasks/syncPalworldTracker.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { isPalworldConfigured, type PalworldPlayer } from "../../../src/lib/palworld.js";
-import { levelFromChannelName, playerChannelName } from "../../../src/scheduled-tasks/syncPalworldTracker.js";
+import { channelNameSlug, playerChannelName } from "../../../src/scheduled-tasks/syncPalworldTracker.js";
 
 function player(overrides: Partial<PalworldPlayer> = {}): PalworldPlayer {
 	return { name: "Z1N1", accountName: "Athena", userId: "steam_76561198271516743", level: 80, ...overrides };
@@ -39,16 +39,31 @@ describe("playerChannelName", () => {
 	});
 });
 
-describe("levelFromChannelName", () => {
-	// If this round trip breaks, every sweep sees a level mismatch and renames every
-	// channel, burning the 2-per-10-minutes rename budget for no reason.
-	it("recovers the level from the name Discord actually stores", () => {
+describe("channelNameSlug", () => {
+	// If this round trip breaks, every sweep sees a mismatch and renames every channel,
+	// burning the 2-per-10-minutes rename budget for no reason.
+	it("matches a name against the form Discord actually stores", () => {
 		for (const p of [player(), player({ name: "", accountName: "" }), player({ level: 1 })]) {
-			expect(levelFromChannelName(discordSanitize(playerChannelName(p)))).toBe(p.level);
+			const name = playerChannelName(p);
+			expect(channelNameSlug(discordSanitize(name))).toBe(channelNameSlug(name));
 		}
 	});
 
-	it("returns null for a channel that carries no level", () => {
-		expect(levelFromChannelName("general")).toBeNull();
+	// Discord silently drops characters we cannot predict, so we drop them first —
+	// otherwise these names would be renamed on every single sweep, forever.
+	it("ignores characters Discord may or may not keep", () => {
+		expect(channelNameSlug("Ω Athena! - Lv 80")).toBe(channelNameSlug("Athena - Lv 80"));
+	});
+
+	it("still separates a level change from a settled name", () => {
+		expect(channelNameSlug(playerChannelName(player({ level: 81 })))).not.toBe(
+			channelNameSlug(playerChannelName(player())),
+		);
+	});
+
+	// The reason existing channels kept their old "character - account" name after the
+	// switch to Steam names: a level-only comparison saw nothing to do.
+	it("sees a name change even when the level is unchanged", () => {
+		expect(channelNameSlug("z1n1-athena-lv-80")).not.toBe(channelNameSlug(playerChannelName(player())));
 	});
 });


### PR DESCRIPTION
Existing tracker channels only compared the **level** parsed out of the channel name, so every channel created before #83 kept its old `character - account - Lv N` name until the player levelled up. The Steam-name change only ever applied to newly created channels.

Now the whole name is compared. The comparison normalises both sides to letters and digits, because Discord lowercases names, turns spaces into dashes and drops characters it dislikes — comparing the raw strings would send a rename on every sweep that can never converge, burning the 2-per-10-minutes rename budget.

Lossy on purpose: two names differing only in punctuation compare equal and keep the name they have.

Tests: 9 passing, including a case asserting `z1n1-athena-lv-80` is now seen as stale at an unchanged level.